### PR TITLE
Add Login page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import Home from './pages/Home'
 import About from './pages/About'
 import Blogs from './pages/Blogs'
+import Login from './pages/Login'
 
 function App() {
   return (
@@ -29,6 +30,12 @@ function App() {
             >
               Blogs
             </Link>
+            <Link
+              to="/login"
+              className="font-semibold text-lg hover:text-blue-600 transition-colors"
+            >
+              Login
+            </Link>
           </div>
         </nav>
         {/* Content Area */}
@@ -37,6 +44,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/about" element={<About />} />
             <Route path="/blogs" element={<Blogs />} />
+            <Route path="/login" element={<Login />} />
           </Routes>
         </main>
       </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { Button } from '../components/ui/button'
+
+function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    try {
+      const res = await axios.post('/api/login', { username, password })
+      const { token } = res.data as { token: string }
+      localStorage.setItem('token', token)
+      setToken(token)
+      navigate('/')
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.message || err.message)
+      } else if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError('Failed to login')
+      }
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h2 className="text-2xl font-bold">Login</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <Button type="submit">Login</Button>
+      </form>
+      {token && <p className="text-green-700">Logged in. Token saved.</p>}
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  )
+}
+
+export default Login


### PR DESCRIPTION
## Summary
- add a Login page
- wire up navigation and route for Login
- redirect to home after successful login

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686cc2653ce8832dba47a9e4c2f82071