### PR TITLE
Add Loading page and adjust routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom'
 
 import Home from './pages/Home'
+import Loading from './pages/Loading'
 import About from './pages/About'
 import Blogs from './pages/Blogs'
 import Login from './pages/Login'
@@ -13,7 +14,7 @@ function App() {
         <nav className="fixed top-0 left-0 right-0 z-10 bg-white border-b shadow flex items-center px-4 h-16">
           <div className="flex-1 flex items-center gap-4">
             <Link
-              to="/"
+              to="/home"
               className="font-semibold text-lg hover:text-blue-600 transition-colors"
             >
               Home
@@ -41,7 +42,8 @@ function App() {
         {/* Content Area */}
         <main className="flex-1 overflow-auto pt-16 bg-gray-50">
           <Routes>
-            <Route path="/" element={<Home />} />
+            <Route path="/" element={<Loading />} />
+            <Route path="/home" element={<Home />} />
             <Route path="/about" element={<About />} />
             <Route path="/blogs" element={<Blogs />} />
             <Route path="/login" element={<Login />} />

--- a/src/pages/Loading.tsx
+++ b/src/pages/Loading.tsx
@@ -1,0 +1,12 @@
+import Footer from '../components/Footer'
+
+function Loading() {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen space-y-4">
+      <div className="animate-spin rounded-full h-16 w-16 border-4 border-gray-300 border-t-transparent" />
+      <Footer />
+    </div>
+  )
+}
+
+export default Loading

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -20,7 +20,7 @@ function Login() {
       const { token } = res.data as { token: string }
       localStorage.setItem('token', token)
       setToken(token)
-      navigate('/')
+      navigate('/home')
     } catch (err) {
       if (axios.isAxiosError(err)) {
         setError(err.response?.data?.message || err.message)


### PR DESCRIPTION
## Summary
- add a `Loading` page with a centered loading spinner
- set `/` route to show the new Loading page
- move the Home page to `/home`
- update login redirect to go to `/home`

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686cc5bc63f4832dafdbb8958af5a187