### PR TITLE
Redirect users on load based on saved token

### DIFF
--- a/src/pages/Loading.tsx
+++ b/src/pages/Loading.tsx
@@ -1,6 +1,19 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import Footer from '../components/Footer'
 
 function Loading() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    if (token) {
+      navigate('/home', { replace: true })
+    } else {
+      navigate('/login', { replace: true })
+    }
+  }, [navigate])
+
   return (
     <div className="flex flex-col items-center justify-center h-screen space-y-4">
       <div className="animate-spin rounded-full h-16 w-16 border-4 border-gray-300 border-t-transparent" />


### PR DESCRIPTION
## Summary
- redirect from the loading page based on whether a token exists in localStorage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_b_686cc8ecd7f4832d8423b631527e2f76