### PR TITLE
Add logout button on Home

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,12 +9,19 @@ import {
 } from '../components/ui/accordion'
 
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 
 function Home() {
   const [version, setVersion] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    localStorage.clear()
+    navigate('/', { replace: true })
+  }
 
   const fetchVersion = async () => {
     setLoading(true)
@@ -36,6 +43,7 @@ function Home() {
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
       <h1 className="text-3xl font-bold mb-6">shadcn/ui Components Showcase</h1>
+      <Button variant="destructive" onClick={handleLogout}>Logout</Button>
 
       {/* Button Showcase */}
       <section>


### PR DESCRIPTION
## Summary
- add logout button on Home page
- wipe localStorage and redirect to root using replace

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_686ccd130dd0832d919e6b82a5e2f2b2