### PR TITLE
Responsive sidebar tweaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function AppRoutes() {
     <div className="flex flex-col h-screen">
       {!hideNavbar && (
         <nav className="fixed top-0 left-0 right-0 z-10 bg-white border-b shadow flex items-center px-4 h-16">
-          <div className="flex-1 flex items-center gap-4">
+          <div className="flex-1 items-center gap-4 hidden md:flex portrait:hidden">
             <Link
               to="/home"
               replace

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { MenuIcon } from 'lucide-react'
 import { Button } from './ui/button'
 import {
@@ -8,25 +8,32 @@ import {
 } from './ui/sheet'
 
 function Sidebar() {
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    localStorage.clear()
+    navigate('/', { replace: true })
+  }
+
   return (
     <Sheet>
       <SheetTrigger asChild>
         <Button
           variant="ghost"
           size="icon"
-          className="ml-auto"
+          className="ml-auto md:hidden portrait:inline-flex"
           aria-label="Open menu"
         >
           <MenuIcon className="size-5" />
         </Button>
       </SheetTrigger>
       <SheetContent
-        side="left"
+        side="right"
         className="w-64 bg-sidebar text-sidebar-foreground"
       >
-        <div className="p-6">
+        <div className="p-6 flex flex-col h-full">
           <h2 className="text-xl font-bold mb-6">Menu</h2>
-          <nav className="flex flex-col gap-3">
+          <nav className="flex flex-col gap-3 flex-1">
             <Link
               to="/home"
               className="rounded-md px-3 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
@@ -46,6 +53,13 @@ function Sidebar() {
               Blogs
             </Link>
           </nav>
+          <Button
+            variant="destructive"
+            onClick={handleLogout}
+            className="mt-auto"
+          >
+            Logout
+          </Button>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,8 @@
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant portrait {@media (orientation: portrait) {&}}
+@custom-variant landscape {@media (orientation: landscape) {&}}
 
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,19 +9,12 @@ import {
 } from '../components/ui/accordion'
 
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 
 function Home() {
   const [version, setVersion] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const navigate = useNavigate()
-
-  const handleLogout = () => {
-    localStorage.clear()
-    navigate('/', { replace: true })
-  }
 
   const fetchVersion = async () => {
     setLoading(true)
@@ -43,10 +36,6 @@ function Home() {
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
       <h1 className="text-3xl font-bold mb-6">shadcn/ui Components Showcase</h1>
-      <Button variant="destructive" onClick={handleLogout}>
-        Logout
-      </Button>
-
       {/* Button Showcase */}
       <section>
         <h2 className="text-xl font-semibold mb-2">Button</h2>


### PR DESCRIPTION
## Summary
- move logout action to sidebar
- show hamburger menu only on portrait or small screens
- hide menu links when burger shows
- let sidebar slide from the right
- support orientation utility classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686cdd19ca20832da21f493d27313569