### PR TITLE
Improve product page currency and auth handling

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+const instance = axios.create()
+
+instance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status
+      if (status === 401 || status === 403) {
+        localStorage.clear()
+        window.location.hash = '/login'
+      }
+    }
+    return Promise.reject(error)
+  }
+)
+
+export default instance

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,9 +4,37 @@ import type { Product } from '../types/Product'
 let products: Product[] = [
   {
     id: 1,
-    name: 'Sample Product',
-    description: 'This is a sample product',
-    price: 9.99,
+    name: 'Nasi Goreng',
+    description: 'Nasi goreng spesial dengan ayam dan telur',
+    price: 25000,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    name: 'Kopi Luwak',
+    description: 'Kopi premium asli Indonesia',
+    price: 75000,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 3,
+    name: 'Sate Ayam',
+    description: 'Sate ayam bumbu kacang lezat',
+    price: 20000,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 4,
+    name: 'Teh Botol',
+    description: 'Minuman teh manis dalam botol',
+    price: 5000,
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 5,
+    name: 'Keripik Pisang',
+    description: 'Camilan keripik pisang renyah',
+    price: 10000,
     createdAt: new Date().toISOString(),
   },
 ]

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,7 +9,7 @@ import {
 } from '../components/ui/accordion'
 
 import { useState } from 'react'
-import axios from 'axios'
+import axios from '../lib/axios'
 
 function Home() {
   const [version, setVersion] = useState<number | null>(null)

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import axios from 'axios'
+import axios from '../lib/axios'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { Button } from '../components/ui/button'

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import axios from 'axios'
+import axios from '../lib/axios'
 import type { Product } from '../types/Product'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -118,8 +118,8 @@ function Products() {
             <tr>
               <th className="px-3 py-2 border-b text-left">Name</th>
               <th className="px-3 py-2 border-b text-left">Description</th>
-              <th className="px-3 py-2 border-b text-left">Price</th>
-              <th className="px-3 py-2 border-b text-left">Actions</th>
+              <th className="px-3 py-2 border-b text-left">Price (IDR)</th>
+              <th className="px-3 py-2 border-b text-right">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -127,8 +127,13 @@ function Products() {
               <tr key={product.id} className="border-b">
                 <td className="px-3 py-2">{product.name}</td>
                 <td className="px-3 py-2">{product.description}</td>
-                <td className="px-3 py-2">${product.price.toFixed(2)}</td>
-                <td className="px-3 py-2 space-x-2">
+                <td className="px-3 py-2">
+                  {new Intl.NumberFormat('id-ID', {
+                    style: 'currency',
+                    currency: 'IDR',
+                  }).format(product.price)}
+                </td>
+                <td className="px-3 py-2 space-x-2 text-right">
                   <Button
                     variant="secondary"
                     size="sm"
@@ -175,13 +180,14 @@ function Products() {
               />
             </div>
             <div>
-              <Label htmlFor="price">Price</Label>
+              <Label htmlFor="price">Price (IDR)</Label>
               <Input
                 id="price"
                 type="number"
-                step="0.01"
+                step="1"
                 value={price}
                 onChange={(e) => setPrice(e.target.value)}
+                placeholder="e.g., 15000"
                 required
               />
             </div>


### PR DESCRIPTION
## Summary
- add axios wrapper with auth error handling
- use the wrapper in pages
- seed Indonesian products
- show prices in IDR
- align action buttons to the right

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686d0f155224832d9aff4ae777208a27