### PR TITLE
Refactor Products page with TanStack DataTable

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,213 @@
+import * as React from 'react'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+  SortingState,
+  ColumnFiltersState,
+  PaginationState,
+  Row,
+} from '@tanstack/react-table'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './ui/table'
+import { Input } from './ui/input'
+import { Button } from './ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select'
+import { Skeleton } from './ui/skeleton'
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react'
+
+export interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  isLoading?: boolean
+  filterColumnId?: string
+  filterOptions?: string[]
+  onRowClick?: (row: Row<TData>) => void
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  isLoading,
+  filterColumnId,
+  filterOptions = [],
+  onRowClick,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [globalFilter, setGlobalFilter] = React.useState('')
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, globalFilter, columnFilters, pagination },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          placeholder="Search..."
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="max-w-xs"
+        />
+        {filterColumnId && filterOptions.length > 0 && (
+          <Select
+            value={(table.getColumn(filterColumnId)?.getFilterValue() as string) ?? ''}
+            onValueChange={(value) => table.getColumn(filterColumnId)?.setFilterValue(value)}
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue placeholder="All" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">All</SelectItem>
+              {filterOptions.map((opt) => (
+                <SelectItem key={opt} value={opt}>
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+      <div className="rounded-md border overflow-x-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  const canSort = header.column.getCanSort()
+                  const sorted = header.column.getIsSorted()
+                  return (
+                    <TableHead
+                      key={header.id}
+                      onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                      className={canSort ? 'cursor-pointer select-none' : ''}
+                    >
+                      <div className="flex items-center gap-1">
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        {canSort && (
+                          sorted === 'asc' ? (
+                            <ArrowUp className="size-3.5" />
+                          ) : sorted === 'desc' ? (
+                            <ArrowDown className="size-3.5" />
+                          ) : (
+                            <ArrowUpDown className="size-3.5 text-muted-foreground" />
+                          )
+                        )}
+                      </div>
+                    </TableHead>
+                  )
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              [...Array(3)].map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell colSpan={columns.length}>
+                    <Skeleton className="h-6 w-full" />
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  onClick={() => onRowClick?.(row)}
+                  className={onRowClick ? 'cursor-pointer' : ''}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className={cell.column.id === 'actions' ? 'text-right' : ''}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm text-muted-foreground">
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={String(table.getState().pagination.pageSize)}
+            onValueChange={(value) => table.setPageSize(Number(value))}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[5, 10, 20, 30].map((size) => (
+                <SelectItem key={size} value={String(size)}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/products-columns.tsx
+++ b/src/pages/products-columns.tsx
@@ -1,0 +1,51 @@
+import { ColumnDef } from '@tanstack/react-table'
+import { Product } from '@/types/Product'
+import { Button } from '@/components/ui/button'
+
+export type ProductTableHandlers = {
+  onEdit: (product: Product) => void
+  onDelete: (product: Product) => void
+}
+
+export function getColumns(handlers: ProductTableHandlers): ColumnDef<Product>[] {
+  return [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+    },
+    {
+      accessorKey: 'description',
+      header: 'Description',
+    },
+    {
+      accessorKey: 'category',
+      header: 'Category',
+    },
+    {
+      accessorKey: 'price',
+      header: 'Price (IDR)',
+      cell: ({ getValue }) => {
+        const value = getValue<number>()
+        return new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' }).format(value)
+      },
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => {
+        const product = row.original
+        return (
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" size="sm" onClick={() => handlers.onEdit(product)}>
+              Edit
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => handlers.onDelete(product)}>
+              Delete
+            </Button>
+          </div>
+        )
+      },
+      enableSorting: false,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- add generic `DataTable` component using TanStack Table and shadcn/ui primitives
- create product column definitions
- rewrite `Products` page to use the new table
- implement search, category filtering, sorting and pagination
- use `AlertDialog` for delete confirmation and skeletons for loading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686d1d9d1ea8832d8d22cbd3eeda8aeb