### PR TITLE
Improve product table actions & pagination

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -32,6 +32,7 @@ import {
   SelectValue,
 } from './ui/select'
 import { Skeleton } from './ui/skeleton'
+import { cn } from '@/lib/utils'
 import {
   ArrowDown,
   ArrowUp,
@@ -121,11 +122,12 @@ export function DataTable<TData, TValue>({
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort()
                   const sorted = header.column.getIsSorted()
+                  const meta = header.column.columnDef.meta as { widthClass?: string } | undefined
                   return (
                     <TableHead
                       key={header.id}
                       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
-                      className={canSort ? 'cursor-pointer select-none' : ''}
+                      className={cn(canSort ? 'cursor-pointer select-none' : '', meta?.widthClass)}
                     >
                       <div className="flex items-center gap-1">
                         {flexRender(header.column.columnDef.header, header.getContext())}
@@ -161,11 +163,17 @@ export function DataTable<TData, TValue>({
                   onClick={() => onRowClick?.(row)}
                   className={onRowClick ? 'cursor-pointer' : ''}
                 >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className={cell.column.id === 'actions' ? 'text-right' : ''}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
+                  {row.getVisibleCells().map((cell) => {
+                    const meta = cell.column.columnDef.meta as { widthClass?: string } | undefined
+                    return (
+                      <TableCell
+                        key={cell.id}
+                        className={cn(cell.column.id === 'actions' ? 'text-right' : '', meta?.widthClass)}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    )
+                  })}
                 </TableRow>
               ))
             ) : (
@@ -191,7 +199,7 @@ export function DataTable<TData, TValue>({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {[5, 10, 20, 30].map((size) => (
+              {[5, 10, 50, 100].map((size) => (
                 <SelectItem key={size} value={String(size)}>
                   {size}
                 </SelectItem>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -146,7 +146,7 @@ function Products() {
     }
   }
 
-  const columns = getColumns({ onEdit: openEdit, onDelete: confirmDelete })
+  const columns = getColumns({ onDetail: openDetail, onEdit: openEdit, onDelete: confirmDelete })
 
   return (
     <div className="max-w-4xl mx-auto p-4 space-y-6">
@@ -161,7 +161,6 @@ function Products() {
         isLoading={loading}
         filterColumnId="category"
         filterOptions={categories}
-        onRowClick={(row) => openDetail(row.original)}
       />
       <Footer />
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>

--- a/src/pages/products-columns.tsx
+++ b/src/pages/products-columns.tsx
@@ -1,8 +1,10 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import type { Product } from '@/types/Product'
 import { Button } from '@/components/ui/button'
+import { Info, Pencil, Trash } from 'lucide-react'
 
 export type ProductTableHandlers = {
+  onDetail: (product: Product) => void
   onEdit: (product: Product) => void
   onDelete: (product: Product) => void
 }
@@ -12,14 +14,17 @@ export function getColumns(handlers: ProductTableHandlers): ColumnDef<Product>[]
     {
       accessorKey: 'name',
       header: 'Name',
+      meta: { widthClass: 'w-40' },
     },
     {
       accessorKey: 'description',
       header: 'Description',
+      meta: { widthClass: 'w-48' },
     },
     {
       accessorKey: 'category',
       header: 'Category',
+      meta: { widthClass: 'w-32' },
     },
     {
       accessorKey: 'price',
@@ -28,19 +33,24 @@ export function getColumns(handlers: ProductTableHandlers): ColumnDef<Product>[]
         const value = getValue<number>()
         return new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' }).format(value)
       },
+      meta: { widthClass: 'w-36' },
     },
     {
       id: 'actions',
       header: 'Actions',
+      meta: { widthClass: 'w-28' },
       cell: ({ row }) => {
         const product = row.original
         return (
-          <div className="flex justify-end gap-2">
-            <Button variant="secondary" size="sm" onClick={() => handlers.onEdit(product)}>
-              Edit
+          <div className="flex justify-end gap-1">
+            <Button variant="ghost" size="icon" onClick={() => handlers.onDetail(product)}>
+              <Info className="size-4" />
             </Button>
-            <Button variant="destructive" size="sm" onClick={() => handlers.onDelete(product)}>
-              Delete
+            <Button variant="secondary" size="icon" onClick={() => handlers.onEdit(product)}>
+              <Pencil className="size-4" />
+            </Button>
+            <Button variant="destructive" size="icon" onClick={() => handlers.onDelete(product)}>
+              <Trash className="size-4" />
             </Button>
           </div>
         )


### PR DESCRIPTION
## Summary
- add width classes for table columns and support in `DataTable`
- convert product actions to icon buttons and include Detail button
- remove row click navigation to detail view
- update pagination options to 5/10/50/100

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react-router-dom', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_686d24414d0c832d847bd89bc19c9fe2