### PR TITLE
Implement router, auth context and MSW setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Mock API with MSW
+
+This project uses [Mock Service Worker](https://mswjs.io/) for local API mocking. Handlers are defined in `src/mocks/handlers.ts`. You can add new endpoints there to support features such as the cart, seller orders or admin approvals. Start the dev server normally with `npm run dev` and MSW will intercept requests.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,101 +1,11 @@
-import {
-  HashRouter as Router,
-  Routes,
-  Route,
-  Link,
-  useLocation,
-} from 'react-router-dom'
-
-import Home from './pages/Home'
-import Loading from './pages/Loading'
-import About from './pages/About'
-import Blogs from './pages/Blogs'
-import Products from './pages/Products'
-import Login from './pages/Login'
-import Sidebar from './components/Sidebar'
-import Title from './components/Title'
-
-function AppRoutes() {
-  const handleLogout = () => {
-    localStorage.clear()
-    window.location.hash = '/'
-  }
-  const location = useLocation()
-  const hideNavbar = location.pathname === '/login' || location.pathname === '/'
-
-  return (
-    <div className="flex flex-col h-screen">
-      {!hideNavbar && (
-        <nav className="fixed top-0 left-0 right-0 z-10 bg-white border-b shadow flex items-center px-4 h-16">
-          {/* Navbar title */}
-          <Title />
-          <div className="flex-1" />
-          <Sidebar onLogout={handleLogout} />
-          {/* Navbar menu: visible only in landscape */}
-          <div className="flex items-center gap-4 hidden md:flex portrait:hidden">
-            <Link
-              to="/home"
-              replace
-              className="font-semibold text-lg hover:text-blue-600 transition-colors"
-            >
-              Home
-            </Link>
-            <Link
-              to="/about"
-              replace
-              className="font-semibold text-lg hover:text-blue-600 transition-colors"
-            >
-              About
-            </Link>
-            <Link
-              to="/blogs"
-              replace
-              className="font-semibold text-lg hover:text-blue-600 transition-colors"
-            >
-              Blogs
-            </Link>
-            <Link
-              to="/products"
-              replace
-              className="font-semibold text-lg hover:text-blue-600 transition-colors"
-            >
-              Products
-            </Link>
-            <button
-              type="button"
-              className="font-semibold text-lg hover:text-red-600 transition-colors"
-              onClick={handleLogout}
-            >
-              Logout
-            </button>
-          </div>
-        </nav>
-      )}
-      <main
-        className={
-          hideNavbar
-            ? 'flex-1 overflow-auto bg-gray-50'
-            : 'flex-1 overflow-auto pt-16 bg-gray-50'
-        }
-      >
-        <Routes>
-          <Route path="/" element={<Loading />} />
-          <Route path="/home" element={<Home />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/blogs" element={<Blogs />} />
-          <Route path="/products" element={<Products />} />
-          <Route path="/login" element={<Login />} />
-        </Routes>
-      </main>
-    </div>
-  )
-}
+import AppRoutes from './AppRoutes'
+import { AuthProvider } from './contexts/AuthContext'
 
 function App() {
   return (
-    <Router>
+    <AuthProvider>
       <AppRoutes />
-    </Router>
+    </AuthProvider>
   )
 }
 

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,0 +1,60 @@
+import { RouterProvider, createHashRouter } from 'react-router-dom'
+import Login from './pages/Login'
+import Loading from './pages/Loading'
+import Placeholder from './components/Placeholder'
+import ProtectedRoute from './components/ProtectedRoute'
+import BuyerLayout from './layouts/BuyerLayout'
+import SellerDashboardLayout from './layouts/SellerDashboardLayout'
+import AdminDashboardLayout from './layouts/AdminDashboardLayout'
+import Forbidden from './pages/Forbidden'
+import NotFound from './pages/NotFound'
+
+const router = createHashRouter([
+  { path: '/', element: <Loading /> },
+  { path: '/auth/login', element: <Login /> },
+  { path: '/auth/register', element: <Placeholder role="Public" name="Register" /> },
+  {
+    element: <ProtectedRoute allowedRoles={['buyer']} />,
+    children: [
+      {
+        path: '/buyer',
+        element: <BuyerLayout />,
+        children: [
+          { index: true, element: <Placeholder role="Buyer" name="Dashboard" /> },
+        ],
+      },
+    ],
+  },
+  {
+    element: <ProtectedRoute allowedRoles={['seller']} />,
+    children: [
+      {
+        path: '/seller',
+        element: <SellerDashboardLayout />,
+        children: [
+          { index: true, element: <Placeholder role="Seller" name="Dashboard" /> },
+        ],
+      },
+    ],
+  },
+  {
+    element: <ProtectedRoute allowedRoles={['admin']} />,
+    children: [
+      {
+        path: '/admin',
+        element: <AdminDashboardLayout />,
+        children: [
+          { index: true, element: <Placeholder role="Admin" name="Dashboard" /> },
+        ],
+      },
+    ],
+  },
+  { path: '/forbidden', element: <Forbidden /> },
+  { path: '*', element: <NotFound /> },
+])
+
+function AppRoutes() {
+  return <RouterProvider router={router} />
+}
+
+export default AppRoutes

--- a/src/components/Placeholder.tsx
+++ b/src/components/Placeholder.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  role: string
+  name: string
+}
+
+function Placeholder({ role, name }: Props) {
+  return (
+    <div className="p-10 text-center space-y-2">
+      <h2 className="text-2xl font-bold">
+        {role} - {name}
+      </h2>
+      <p className="text-gray-500">Replace this page with real content.</p>
+    </div>
+  )
+}
+
+export default Placeholder

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+
+interface Props {
+  allowedRoles: string[]
+}
+
+function ProtectedRoute({ allowedRoles }: Props) {
+  const { user } = useAuth()
+  if (!user) {
+    return <Navigate to="/auth/login" replace />
+  }
+  if (!allowedRoles.includes(user.role)) {
+    return <Navigate to="/forbidden" replace />
+  }
+  return <Outlet />
+}
+
+export default ProtectedRoute

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,11 +3,14 @@ import { MenuIcon } from 'lucide-react'
 import { Button } from './ui/button'
 import { Sheet, SheetTrigger, SheetContent, SheetClose } from './ui/sheet'
 
+export type SidebarLink = { to: string; label: string }
+
 type SidebarProps = {
+  links: SidebarLink[]
   onLogout?: () => void
 }
 
-function Sidebar({ onLogout }: SidebarProps) {
+function Sidebar({ links, onLogout }: SidebarProps) {
   const navigate = useNavigate()
 
   const handleLogout = () => {
@@ -38,38 +41,16 @@ function Sidebar({ onLogout }: SidebarProps) {
         <div className="p-6 flex flex-col h-full">
           <h2 className="text-xl font-bold mb-6">Menu</h2>
           <nav className="flex flex-col gap-3 flex-1">
-            <SheetClose asChild>
-              <Link
-                to="/home"
-                className="rounded-md px-3 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
-              >
-                Home
-              </Link>
-            </SheetClose>
-            <SheetClose asChild>
-              <Link
-                to="/about"
-                className="rounded-md px-3 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
-              >
-                About
-              </Link>
-            </SheetClose>
-            <SheetClose asChild>
-              <Link
-                to="/blogs"
-                className="rounded-md px-3 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
-              >
-                Blogs
-              </Link>
-            </SheetClose>
-            <SheetClose asChild>
-              <Link
-                to="/products"
-                className="rounded-md px-3 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
-              >
-                Products
-              </Link>
-            </SheetClose>
+            {links.map((l) => (
+              <SheetClose asChild key={l.to}>
+                <Link
+                  to={l.to}
+                  className="rounded-md px-3 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
+                >
+                  {l.label}
+                </Link>
+              </SheetClose>
+            ))}
           </nav>
           <SheetClose asChild>
             <Button

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import axios from '@/lib/axios'
+
+export type Role = 'buyer' | 'seller' | 'admin'
+
+export interface User {
+  id: number
+  name: string
+  role: Role
+}
+
+interface AuthContextType {
+  user: User | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  login: async (_u: string, _p: string) => {},
+  logout: () => {},
+})
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    const stored = localStorage.getItem('user')
+    if (token && stored) {
+      setUser(JSON.parse(stored) as User)
+    }
+  }, [])
+
+  const login = async (username: string, password: string) => {
+    const res = await axios.post('/api/auth/login', { username, password })
+    const { token, user } = res.data as { token: string; user: User }
+    localStorage.setItem('token', token)
+    localStorage.setItem('user', JSON.stringify(user))
+    setUser(user)
+  }
+
+  const logout = () => {
+    localStorage.removeItem('token')
+    localStorage.removeItem('user')
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/src/layouts/AdminDashboardLayout.tsx
+++ b/src/layouts/AdminDashboardLayout.tsx
@@ -1,0 +1,20 @@
+import Sidebar from '@/components/Sidebar'
+import { Outlet } from 'react-router-dom'
+
+function AdminDashboardLayout() {
+  const links = [
+    { to: '/admin', label: 'Dashboard' },
+  ]
+  return (
+    <div className="flex min-h-screen">
+      <aside className="border-r p-4">
+        <Sidebar links={links} />
+      </aside>
+      <main className="flex-1 p-4">
+        <Outlet />
+      </main>
+    </div>
+  )
+}
+
+export default AdminDashboardLayout

--- a/src/layouts/BuyerLayout.tsx
+++ b/src/layouts/BuyerLayout.tsx
@@ -1,0 +1,22 @@
+import Sidebar from '@/components/Sidebar'
+import Footer from '@/components/Footer'
+import { Outlet } from 'react-router-dom'
+
+function BuyerLayout() {
+  const links = [
+    { to: '/buyer', label: 'Dashboard' },
+  ]
+  return (
+    <div className="flex flex-col min-h-screen">
+      <nav className="flex items-center justify-between border-b p-4">
+        <Sidebar links={links} />
+      </nav>
+      <main className="flex-1 p-4">
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default BuyerLayout

--- a/src/layouts/SellerDashboardLayout.tsx
+++ b/src/layouts/SellerDashboardLayout.tsx
@@ -1,0 +1,20 @@
+import Sidebar from '@/components/Sidebar'
+import { Outlet } from 'react-router-dom'
+
+function SellerDashboardLayout() {
+  const links = [
+    { to: '/seller', label: 'Dashboard' },
+  ]
+  return (
+    <div className="flex min-h-screen">
+      <aside className="border-r p-4">
+        <Sidebar links={links} />
+      </aside>
+      <main className="flex-1 p-4">
+        <Outlet />
+      </main>
+    </div>
+  )
+}
+
+export default SellerDashboardLayout

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -9,7 +9,7 @@ instance.interceptors.response.use(
       const status = error.response?.status
       if (status === 401 || status === 403) {
         localStorage.clear()
-        window.location.hash = '/login'
+        window.location.hash = '/auth/login'
       }
     }
     return Promise.reject(error)

--- a/src/mocks/data/products.json
+++ b/src/mocks/data/products.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "name": "Sample Product A",
+    "description": "First sample product",
+    "price": 10000,
+    "category": "Demo",
+    "createdAt": "2025-01-01T00:00:00.000Z"
+  },
+  {
+    "id": 2,
+    "name": "Sample Product B",
+    "description": "Second sample product",
+    "price": 20000,
+    "category": "Demo",
+    "createdAt": "2025-01-02T00:00:00.000Z"
+  }
+]

--- a/src/mocks/data/users.json
+++ b/src/mocks/data/users.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "name": "Alice Buyer", "username": "buyer", "password": "buyer", "role": "buyer" },
+  { "id": 2, "name": "Sam Seller", "username": "seller", "password": "seller", "role": "seller" },
+  { "id": 3, "name": "Admin", "username": "admin", "password": "admin", "role": "admin" }
+]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,260 +1,32 @@
 import { rest } from 'msw'
+import productsData from './data/products.json'
+import users from './data/users.json'
 import type { Product } from '../types/Product'
 
-let products: Product[] = [
-  {
-    id: 1,
-    name: 'Nasi Goreng',
-    description: 'Nasi goreng spesial dengan ayam dan telur',
-    price: 25000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 2,
-    name: 'Kopi Luwak',
-    description: 'Kopi premium asli Indonesia',
-    price: 75000,
-    category: 'Minuman',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 3,
-    name: 'Sate Ayam',
-    description: 'Sate ayam bumbu kacang lezat',
-    price: 20000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 4,
-    name: 'Teh Botol',
-    description: 'Minuman teh manis dalam botol',
-    price: 5000,
-    category: 'Minuman',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 5,
-    name: 'Keripik Pisang',
-    description: 'Camilan keripik pisang renyah',
-    price: 10000,
-    category: 'Camilan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 6,
-    name: 'Bakso Malang',
-    description: 'Bakso daging sapi dengan kuah gurih',
-    price: 18000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 7,
-    name: 'Es Cendol',
-    description: 'Minuman tradisional dengan santan dan gula merah',
-    price: 12000,
-    category: 'Minuman',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 8,
-    name: 'Mi Aceh',
-    description: 'Mi pedas khas Aceh dengan irisan daging sapi',
-    price: 30000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 9,
-    name: 'Rendang Padang',
-    description: 'Rendang sapi bumbu khas Padang',
-    price: 45000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 10,
-    name: 'Gudeg Jogja',
-    description: 'Nangka muda dimasak manis khas Yogyakarta',
-    price: 35000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 11,
-    name: 'Laptop Lokal',
-    description: 'Laptop buatan produsen lokal dengan spesifikasi mumpuni',
-    price: 5500000,
-    category: 'Elektronik',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 12,
-    name: 'Kaos Batik',
-    description: 'Kaos dengan motif batik modern',
-    price: 80000,
-    category: 'Fashion',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 13,
-    name: 'Sneakers Lokal',
-    description: 'Sepatu sneakers produksi lokal',
-    price: 350000,
-    category: 'Fashion',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 14,
-    name: 'Tas Rotan',
-    description: 'Tas anyaman rotan khas Bali',
-    price: 150000,
-    category: 'Fashion',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 15,
-    name: 'Kamera Aksi',
-    description: 'Kamera aksi tahan air untuk petualangan',
-    price: 900000,
-    category: 'Elektronik',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 16,
-    name: 'Minyak Telon',
-    description: 'Minyak telon hangat untuk bayi',
-    price: 25000,
-    category: 'Kesehatan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 17,
-    name: 'Balsem Gosok',
-    description: 'Balsem gosok untuk meredakan pegal',
-    price: 18000,
-    category: 'Kesehatan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 18,
-    name: 'Jas Hujan',
-    description: 'Jas hujan model ponco tahan air',
-    price: 50000,
-    category: 'Olahraga',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 19,
-    name: 'Raket Badminton',
-    description: 'Raket ringan untuk bermain badminton',
-    price: 220000,
-    category: 'Olahraga',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 20,
-    name: 'Matras Yoga',
-    description: 'Matras yoga anti slip',
-    price: 150000,
-    category: 'Olahraga',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 21,
-    name: 'Makeup Remover',
-    description: 'Pembersih makeup yang lembut di kulit',
-    price: 60000,
-    category: 'Kecantikan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 22,
-    name: 'Lipstik Merah',
-    description: 'Lipstik warna merah klasik tahan lama',
-    price: 75000,
-    category: 'Kecantikan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 23,
-    name: 'Serum Wajah',
-    description: 'Serum wajah untuk kulit glowing',
-    price: 120000,
-    category: 'Kecantikan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 24,
-    name: 'Sambal Roa',
-    description: 'Sambal khas Manado pedas gurih',
-    price: 35000,
-    category: 'Makanan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 25,
-    name: 'Kerupuk Udang',
-    description: 'Kerupuk udang renyah ukuran besar',
-    price: 20000,
-    category: 'Camilan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 26,
-    name: 'Baju Koko',
-    description: 'Baju koko pria lengan panjang',
-    price: 180000,
-    category: 'Fashion',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 27,
-    name: 'Tablet Lokal',
-    description: 'Tablet Android untuk belajar online',
-    price: 2500000,
-    category: 'Elektronik',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 28,
-    name: 'Kopi Tubruk',
-    description: 'Kopi hitam khas Indonesia',
-    price: 15000,
-    category: 'Minuman',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 29,
-    name: 'Dodol Garut',
-    description: 'Camilan manis khas Garut',
-    price: 25000,
-    category: 'Camilan',
-    createdAt: new Date().toISOString(),
-  },
-  {
-    id: 30,
-    name: 'Batik Tulis',
-    description: 'Kain batik tulis motif klasik',
-    price: 650000,
-    category: 'Fashion',
-    createdAt: new Date().toISOString(),
-  },
-]
+let products: Product[] = [...productsData]
 
 export const handlers = [
-  rest.post('/api/login', async (req, res, ctx) => {
+  rest.post('/api/auth/login', async (req, res, ctx) => {
     const { username, password } = await req.json()
-    // Example: accept any username/password, return a fake token
-    if (username && password) {
-      return res(ctx.status(200), ctx.json({ token: 'my-secret-token' }))
+    const user = users.find(
+      (u) => u.username === username && u.password === password
+    )
+    if (!user) {
+      return res(ctx.status(401), ctx.json({ message: 'Invalid credentials' }))
     }
-    return res(ctx.status(400), ctx.json({ message: 'access denied' }))
+    return res(
+      ctx.status(200),
+      ctx.json({ token: `token-${user.id}`, user: { id: user.id, name: user.name, role: user.role } })
+    )
   }),
-  rest.get('/api/version', (_, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ value: 1 }))
+  rest.get('/api/users/me', (req, res, ctx) => {
+    const auth = req.headers.get('authorization')
+    if (!auth) return res(ctx.status(401))
+    const token = auth.replace('Bearer ', '')
+    const id = Number(token.split('token-')[1])
+    const user = users.find((u) => u.id === id)
+    if (!user) return res(ctx.status(401))
+    return res(ctx.status(200), ctx.json({ id: user.id, name: user.name, role: user.role }))
   }),
   rest.get('/api/products', (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(products))

--- a/src/pages/Forbidden.tsx
+++ b/src/pages/Forbidden.tsx
@@ -1,0 +1,10 @@
+function Forbidden() {
+  return (
+    <div className="p-10 text-center">
+      <h1 className="text-3xl font-bold mb-2">403 - Forbidden</h1>
+      <p>You do not have access to this page.</p>
+    </div>
+  )
+}
+
+export default Forbidden

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import axios from '../lib/axios'
 import * as Axios from 'axios'
+import { useAuth } from '@/contexts/AuthContext'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { Button } from '../components/ui/button'
@@ -20,16 +20,15 @@ function Login() {
   const [error, setError] = useState<string | null>(null)
   const [token, setToken] = useState<string | null>(null)
   const navigate = useNavigate()
+  const { login } = useAuth()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
     try {
-      const res = await axios.post('/api/login', { username, password })
-      const { token } = res.data as { token: string }
-      localStorage.setItem('token', token)
-      setToken(token)
-      navigate('/home', { replace: true })
+      await login(username, password)
+      setToken(localStorage.getItem('token'))
+      navigate('/buyer', { replace: true })
     } catch (err) {
       if (Axios.isAxiosError(err)) {
         setError(err.response?.data?.message || err.message)

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,10 @@
+function NotFound() {
+  return (
+    <div className="p-10 text-center">
+      <h1 className="text-3xl font-bold mb-2">404 - Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
## Summary
- add role-based routing via `createBrowserRouter`
- implement an `AuthContext` with login/logout
- add ProtectedRoute wrapper
- build minimal layouts for Buyer/Seller/Admin
- create placeholder pages and basic forbidden/404 pages
- make sidebar links dynamic
- set up MSW with login and users endpoints
- document MSW mock API usage
- **switch to hash-based router for compatibility**

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing packages prevent TypeScript compilation)*

------
https://chatgpt.com/codex/tasks/task_b_686dc7c02448832d8067bb190bd3b58e