### PR TITLE
Add Navbar and responsive tables

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,33 @@
+import { ArrowLeft } from 'lucide-react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import Container from '@/components/Container'
+import { Button } from '@/components/ui/button'
+import { getPageTitle, isNestedRoute } from '@/lib/nav'
+
+function Navbar() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const title = getPageTitle(location.pathname)
+  const showBack = isNestedRoute(location.pathname)
+
+  return (
+    <div className="border-b py-4">
+      <Container className="relative flex items-center justify-center">
+        {showBack && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate(-1)}
+            aria-label="Go back"
+            className="absolute left-4 flex items-center justify-center focus-visible:ring"
+          >
+            <ArrowLeft className="size-5" />
+          </Button>
+        )}
+        <span className="font-semibold">{title}</span>
+      </Container>
+    </div>
+  )
+}
+
+export default Navbar

--- a/src/layouts/AdminDashboardLayout.tsx
+++ b/src/layouts/AdminDashboardLayout.tsx
@@ -1,5 +1,6 @@
 import Sidebar from '@/components/Sidebar'
 import Container from '@/components/Container'
+import Navbar from '@/components/Navbar'
 import { Outlet } from 'react-router-dom'
 
 function AdminDashboardLayout() {
@@ -20,6 +21,7 @@ function AdminDashboardLayout() {
       </aside>
       <main className="flex-1 py-4">
         <Container>
+          <Navbar />
           <Outlet />
         </Container>
       </main>

--- a/src/layouts/SellerDashboardLayout.tsx
+++ b/src/layouts/SellerDashboardLayout.tsx
@@ -1,5 +1,6 @@
 import Sidebar from '@/components/Sidebar'
 import Container from '@/components/Container'
+import Navbar from '@/components/Navbar'
 import { Outlet } from 'react-router-dom'
 
 function SellerDashboardLayout() {
@@ -19,6 +20,7 @@ function SellerDashboardLayout() {
       </nav>
       <main className="flex-1 py-4">
         <Container>
+          <Navbar />
           <Outlet />
         </Container>
       </main>

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,0 +1,11 @@
+export function isNestedRoute(path: string): boolean {
+  return path.split('/').filter(Boolean).length > 3
+}
+
+export function getPageTitle(path: string): string {
+  if (path.startsWith('/seller/products/new')) return 'Add Product'
+  if (/^\/seller\/products\/[^/]+\/edit/.test(path)) return 'Edit Product'
+  if (path.startsWith('/seller/orders')) return 'Orders'
+  if (path.startsWith('/admin/users')) return 'Manage Users'
+  return 'Dashboard'
+}

--- a/src/pages/admin/ManageProducts.tsx
+++ b/src/pages/admin/ManageProducts.tsx
@@ -26,9 +26,21 @@ function ManageProducts() {
   }
 
   const columns: ColumnDef<AdminProduct>[] = [
-    { accessorKey: 'name', header: 'Name' },
-    { accessorKey: 'price', header: 'Price' },
-    { accessorKey: 'status', header: 'Status' },
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      meta: { widthClass: 'w-40', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'price',
+      header: 'Price',
+      meta: { widthClass: 'hidden md:table-cell w-24', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      meta: { widthClass: 'w-24', cellClass: 'truncate' },
+    },
     {
       id: 'actions',
       header: 'Actions',

--- a/src/pages/admin/ManageSellers.tsx
+++ b/src/pages/admin/ManageSellers.tsx
@@ -26,8 +26,16 @@ function ManageSellers() {
   }
 
   const columns: ColumnDef<AdminSeller>[] = [
-    { accessorKey: 'name', header: 'Name' },
-    { accessorKey: 'status', header: 'Status' },
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      meta: { widthClass: 'w-40', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      meta: { widthClass: 'hidden md:table-cell w-28', cellClass: 'truncate' },
+    },
     {
       id: 'actions',
       header: 'Actions',

--- a/src/pages/admin/ManageUsers.tsx
+++ b/src/pages/admin/ManageUsers.tsx
@@ -36,9 +36,21 @@ function ManageUsers() {
   }
 
   const columns: ColumnDef<AdminUser>[] = [
-    { accessorKey: 'name', header: 'Name' },
-    { accessorKey: 'role', header: 'Role' },
-    { accessorKey: 'status', header: 'Status' },
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      meta: { widthClass: 'w-40', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'role',
+      header: 'Role',
+      meta: { widthClass: 'hidden md:table-cell w-24', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      meta: { widthClass: 'w-24', cellClass: 'truncate' },
+    },
     {
       id: 'actions',
       header: 'Actions',

--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -26,8 +26,19 @@ function Reports() {
   }
 
   const columns: ColumnDef<AdminReport>[] = [
-    { accessorKey: 'message', header: 'Message', meta: { widthClass: 'w-64' } },
-    { accessorKey: 'status', header: 'Status' },
+    {
+      accessorKey: 'message',
+      header: 'Message',
+      meta: {
+        widthClass: 'w-64',
+        cellClass: 'whitespace-normal break-words',
+      },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      meta: { widthClass: 'hidden md:table-cell w-24', cellClass: 'truncate' },
+    },
     {
       id: 'actions',
       header: 'Actions',

--- a/src/pages/seller/MyProducts.tsx
+++ b/src/pages/seller/MyProducts.tsx
@@ -28,8 +28,16 @@ function MyProducts() {
   }
 
   const columns: ColumnDef<SellerProduct>[] = [
-    { accessorKey: 'name', header: 'Name' },
-    { accessorKey: 'price', header: 'Price' },
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      meta: { widthClass: 'w-40', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'price',
+      header: 'Price',
+      meta: { widthClass: 'hidden md:table-cell w-32', cellClass: 'truncate' },
+    },
     {
       id: 'actions',
       header: 'Actions',

--- a/src/pages/seller/OrdersReceived.tsx
+++ b/src/pages/seller/OrdersReceived.tsx
@@ -26,10 +26,26 @@ function OrdersReceived() {
   }
 
   const columns: ColumnDef<SellerOrder>[] = [
-    { accessorKey: 'productName', header: 'Product' },
-    { accessorKey: 'quantity', header: 'Qty' },
-    { accessorKey: 'total', header: 'Total' },
-    { accessorKey: 'status', header: 'Status' },
+    {
+      accessorKey: 'productName',
+      header: 'Product',
+      meta: { widthClass: 'w-40', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'quantity',
+      header: 'Qty',
+      meta: { widthClass: 'hidden md:table-cell w-20', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'total',
+      header: 'Total',
+      meta: { widthClass: 'hidden md:table-cell w-24', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      meta: { widthClass: 'w-28', cellClass: 'truncate' },
+    },
     {
       id: 'actions',
       header: 'Actions',

--- a/src/pages/seller/Payouts.tsx
+++ b/src/pages/seller/Payouts.tsx
@@ -20,8 +20,16 @@ function Payouts() {
   }, [])
 
   const columns: ColumnDef<SellerPayout>[] = [
-    { accessorKey: 'date', header: 'Date' },
-    { accessorKey: 'amount', header: 'Amount' },
+    {
+      accessorKey: 'date',
+      header: 'Date',
+      meta: { widthClass: 'w-32', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'amount',
+      header: 'Amount',
+      meta: { widthClass: 'w-32', cellClass: 'truncate' },
+    },
   ]
 
   return <DataTable columns={columns} data={data} isLoading={loading} />


### PR DESCRIPTION
## Summary
- introduce `Navbar` component with back button
- provide `getPageTitle` and `isNestedRoute` helpers
- display `Navbar` in seller and admin dashboard layouts
- apply responsive column classes for all data tables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'msw')*

------
https://chatgpt.com/codex/tasks/task_b_686e6e043d28832d9299567cb6ac8721