### PR TITLE
Improve loading UI

### DIFF
--- a/client/components/ui/spinner.tsx
+++ b/client/components/ui/spinner.tsx
@@ -1,0 +1,13 @@
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+function Spinner({ className }: { className?: string }) {
+  return (
+    <div className={cn('flex justify-center items-center py-10', className)}>
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <span className="sr-only">Loading...</span>
+    </div>
+  )
+}
+
+export { Spinner }

--- a/client/pages/admin/ViewProduct.tsx
+++ b/client/pages/admin/ViewProduct.tsx
@@ -5,6 +5,7 @@ import type { Product } from '@/types/Product'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 function ViewProduct() {
   const { id } = useParams<{ id: string }>()
@@ -15,7 +16,7 @@ function ViewProduct() {
 
   const fetchProduct = useCallback(async () => {
     if (!id) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<Product>(`/api/admin/products/${id}`)
@@ -30,7 +31,7 @@ function ViewProduct() {
 
   const handleStatusUpdate = async (action: string) => {
     if (!product) return
-    
+
     try {
       await axios.patch(`/api/admin/products/${product.id}`, { action })
       await fetchProduct() // Refresh the product data
@@ -44,17 +45,22 @@ function ViewProduct() {
     fetchProduct()
   }, [fetchProduct])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!product) return <div>Product not found.</div>
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return 'bg-green-100 text-green-800'
-      case 'inactive': return 'bg-gray-100 text-gray-800'
-      case 'pending': return 'bg-yellow-100 text-yellow-800'
-      case 'flagged': return 'bg-red-100 text-red-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case 'active':
+        return 'bg-green-100 text-green-800'
+      case 'inactive':
+        return 'bg-gray-100 text-gray-800'
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'flagged':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
@@ -77,7 +83,9 @@ function ViewProduct() {
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               {product.name}
-              <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(product.status || 'inactive')}`}>
+              <span
+                className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(product.status || 'inactive')}`}
+              >
                 {product.status}
               </span>
             </CardTitle>
@@ -92,18 +100,21 @@ function ViewProduct() {
                 />
               </div>
             )}
-            
+
             <div className="space-y-2">
               <div>
                 <span className="font-semibold">Price:</span> ${product.price}
               </div>
               <div>
-                <span className="font-semibold">Seller ID:</span> {product.sellerId}
+                <span className="font-semibold">Seller ID:</span>{' '}
+                {product.sellerId}
               </div>
               {product.description && (
                 <div>
                   <span className="font-semibold">Description:</span>
-                  <p className="mt-1 text-sm text-gray-600">{product.description}</p>
+                  <p className="mt-1 text-sm text-gray-600">
+                    {product.description}
+                  </p>
                 </div>
               )}
             </div>
@@ -132,7 +143,7 @@ function ViewProduct() {
                 </Button>
               </>
             )}
-            
+
             {product.status === 'active' && (
               <>
                 <Button
@@ -151,7 +162,7 @@ function ViewProduct() {
                 </Button>
               </>
             )}
-            
+
             {product.status === 'flagged' && (
               <>
                 <Button
@@ -176,4 +187,4 @@ function ViewProduct() {
   )
 }
 
-export default ViewProduct 
+export default ViewProduct

--- a/client/pages/admin/ViewSeller.tsx
+++ b/client/pages/admin/ViewSeller.tsx
@@ -5,6 +5,7 @@ import type { Seller } from '@/server/schema'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 function ViewSeller() {
   const { id } = useParams<{ id: string }>()
@@ -15,7 +16,7 @@ function ViewSeller() {
 
   const fetchSeller = useCallback(async () => {
     if (!id) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<Seller>(`/api/admin/sellers/${id}`)
@@ -30,7 +31,7 @@ function ViewSeller() {
 
   const handleStatusUpdate = async (action: string) => {
     if (!seller) return
-    
+
     try {
       await axios.patch(`/api/admin/sellers/${seller.id}`, { action })
       await fetchSeller() // Refresh the seller data
@@ -44,16 +45,20 @@ function ViewSeller() {
     fetchSeller()
   }, [fetchSeller])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!seller) return <div>Seller not found.</div>
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return 'bg-green-100 text-green-800'
-      case 'inactive': return 'bg-gray-100 text-gray-800'
-      case 'pending': return 'bg-yellow-100 text-yellow-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case 'active':
+        return 'bg-green-100 text-green-800'
+      case 'inactive':
+        return 'bg-gray-100 text-gray-800'
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
@@ -76,7 +81,9 @@ function ViewSeller() {
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               {seller.name}
-              <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(seller.status || 'inactive')}`}>
+              <span
+                className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(seller.status || 'inactive')}`}
+              >
                 {seller.status}
               </span>
             </CardTitle>
@@ -91,7 +98,7 @@ function ViewSeller() {
                 />
               </div>
             )}
-            
+
             <div className="space-y-2">
               <div>
                 <span className="font-semibold">Seller ID:</span> {seller.id}
@@ -137,7 +144,7 @@ function ViewSeller() {
                 </Button>
               </>
             )}
-            
+
             {seller.status === 'active' && (
               <Button
                 variant="destructive"
@@ -147,7 +154,7 @@ function ViewSeller() {
                 Deactivate Seller
               </Button>
             )}
-            
+
             {seller.status === 'inactive' && (
               <Button
                 className="w-full"
@@ -163,4 +170,4 @@ function ViewSeller() {
   )
 }
 
-export default ViewSeller 
+export default ViewSeller

--- a/client/pages/admin/ViewUser.tsx
+++ b/client/pages/admin/ViewUser.tsx
@@ -5,6 +5,7 @@ import type { User } from '@/server/schema'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 function ViewUser() {
   const { id } = useParams<{ id: string }>()
@@ -15,7 +16,7 @@ function ViewUser() {
 
   const fetchUser = useCallback(async () => {
     if (!id) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<User>(`/api/admin/users/${id}`)
@@ -30,7 +31,7 @@ function ViewUser() {
 
   const handleToggleBan = async () => {
     if (!user) return
-    
+
     try {
       await axios.patch(`/api/admin/users/${user.id}`, { action: 'toggleBan' })
       await fetchUser() // Refresh the user data
@@ -44,25 +45,33 @@ function ViewUser() {
     fetchUser()
   }, [fetchUser])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!user) return <div>User not found.</div>
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return 'bg-green-100 text-green-800'
-      case 'banned': return 'bg-red-100 text-red-800'
-      case 'inactive': return 'bg-gray-100 text-gray-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case 'active':
+        return 'bg-green-100 text-green-800'
+      case 'banned':
+        return 'bg-red-100 text-red-800'
+      case 'inactive':
+        return 'bg-gray-100 text-gray-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
   const getRoleColor = (role: string) => {
     switch (role) {
-      case 'admin': return 'bg-purple-100 text-purple-800'
-      case 'seller': return 'bg-blue-100 text-blue-800'
-      case 'buyer': return 'bg-green-100 text-green-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case 'admin':
+        return 'bg-purple-100 text-purple-800'
+      case 'seller':
+        return 'bg-blue-100 text-blue-800'
+      case 'buyer':
+        return 'bg-green-100 text-green-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
@@ -86,10 +95,14 @@ function ViewUser() {
             <CardTitle className="flex items-center justify-between">
               {user.name}
               <div className="flex gap-2">
-                <span className={`px-2 py-1 rounded-full text-xs font-medium ${getRoleColor(user.role || 'buyer')}`}>
+                <span
+                  className={`px-2 py-1 rounded-full text-xs font-medium ${getRoleColor(user.role || 'buyer')}`}
+                >
                   {user.role}
                 </span>
-                <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status || 'inactive')}`}>
+                <span
+                  className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status || 'inactive')}`}
+                >
                   {user.status}
                 </span>
               </div>
@@ -144,9 +157,12 @@ function ViewUser() {
             >
               {user.status === 'banned' ? 'Unban User' : 'Ban User'}
             </Button>
-            
+
             <div className="text-sm text-gray-600 mt-4">
-              <p><strong>Note:</strong> Banning a user will prevent them from accessing the platform.</p>
+              <p>
+                <strong>Note:</strong> Banning a user will prevent them from
+                accessing the platform.
+              </p>
               <p className="mt-2">Unbanning will restore their access.</p>
             </div>
           </CardContent>
@@ -156,4 +172,4 @@ function ViewUser() {
   )
 }
 
-export default ViewUser 
+export default ViewUser

--- a/client/pages/buyer/OrderDetail.tsx
+++ b/client/pages/buyer/OrderDetail.tsx
@@ -4,22 +4,23 @@ import axios from '@/lib/axios'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft, Package, Truck, CheckCircle, Clock } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 // Interface matching the OpenAPI specification
 interface OrderDetail {
-  id: number;
-  items: string; // JSON string of cart items
-  total: number;
-  status: string;
-  createdAt: string;
-  shippingAddress?: string;
-  paymentMethod?: string;
-  trackingNumber?: string;
+  id: number
+  items: string // JSON string of cart items
+  total: number
+  status: string
+  createdAt: string
+  shippingAddress?: string
+  paymentMethod?: string
+  trackingNumber?: string
 }
 
 interface OrderItem {
-  productId: number;
-  quantity: number;
+  productId: number
+  quantity: number
 }
 
 function OrderDetail() {
@@ -31,7 +32,7 @@ function OrderDetail() {
 
   const fetchOrder = useCallback(async () => {
     if (!id) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<OrderDetail>(`/api/buyer/orders/${id}`)
@@ -48,29 +49,41 @@ function OrderDetail() {
     fetchOrder()
   }, [fetchOrder])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!order) return <div>Order not found.</div>
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'pending': return 'bg-yellow-100 text-yellow-800'
-      case 'processing': return 'bg-blue-100 text-blue-800'
-      case 'shipped': return 'bg-purple-100 text-purple-800'
-      case 'delivered': return 'bg-green-100 text-green-800'
-      case 'cancelled': return 'bg-red-100 text-red-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'processing':
+        return 'bg-blue-100 text-blue-800'
+      case 'shipped':
+        return 'bg-purple-100 text-purple-800'
+      case 'delivered':
+        return 'bg-green-100 text-green-800'
+      case 'cancelled':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'pending': return <Clock className="h-4 w-4" />
-      case 'processing': return <Package className="h-4 w-4" />
-      case 'shipped': return <Truck className="h-4 w-4" />
-      case 'delivered': return <CheckCircle className="h-4 w-4" />
-      case 'cancelled': return <Clock className="h-4 w-4" />
-      default: return <Clock className="h-4 w-4" />
+      case 'pending':
+        return <Clock className="h-4 w-4" />
+      case 'processing':
+        return <Package className="h-4 w-4" />
+      case 'shipped':
+        return <Truck className="h-4 w-4" />
+      case 'delivered':
+        return <CheckCircle className="h-4 w-4" />
+      case 'cancelled':
+        return <Clock className="h-4 w-4" />
+      default:
+        return <Clock className="h-4 w-4" />
     }
   }
 
@@ -80,11 +93,7 @@ function OrderDetail() {
   return (
     <div className="max-w-4xl mx-auto p-6">
       <div className="flex items-center gap-4 mb-6">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => navigate('/orders')}
-        >
+        <Button variant="outline" size="sm" onClick={() => navigate('/orders')}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back to Orders
         </Button>
@@ -103,11 +112,14 @@ function OrderDetail() {
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
-                <span className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusColor(order.status)}`}>
+                <span
+                  className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusColor(order.status)}`}
+                >
                   {order.status}
                 </span>
                 <span className="text-sm text-gray-500">
-                  {order.createdAt && new Date(order.createdAt).toLocaleDateString()}
+                  {order.createdAt &&
+                    new Date(order.createdAt).toLocaleDateString()}
                 </span>
               </div>
             </CardContent>
@@ -121,10 +133,17 @@ function OrderDetail() {
               {orderItems.length > 0 ? (
                 <div className="space-y-3">
                   {orderItems.map((item: OrderItem, index: number) => (
-                    <div key={index} className="flex items-center justify-between p-3 border rounded">
+                    <div
+                      key={index}
+                      className="flex items-center justify-between p-3 border rounded"
+                    >
                       <div>
-                        <p className="font-medium">Product ID: {item.productId}</p>
-                        <p className="text-sm text-gray-600">Quantity: {item.quantity}</p>
+                        <p className="font-medium">
+                          Product ID: {item.productId}
+                        </p>
+                        <p className="text-sm text-gray-600">
+                          Quantity: {item.quantity}
+                        </p>
                       </div>
                     </div>
                   ))}
@@ -192,37 +211,44 @@ function OrderDetail() {
                   <div>
                     <p className="text-sm font-medium">Order Placed</p>
                     <p className="text-xs text-gray-500">
-                      {order.createdAt && new Date(order.createdAt).toLocaleString()}
+                      {order.createdAt &&
+                        new Date(order.createdAt).toLocaleString()}
                     </p>
                   </div>
                 </div>
-                
+
                 {order.status !== 'pending' && (
                   <div className="flex items-center gap-3">
                     <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
                     <div>
                       <p className="text-sm font-medium">Processing</p>
-                      <p className="text-xs text-gray-500">Order is being processed</p>
+                      <p className="text-xs text-gray-500">
+                        Order is being processed
+                      </p>
                     </div>
                   </div>
                 )}
-                
+
                 {['shipped', 'delivered'].includes(order.status) && (
                   <div className="flex items-center gap-3">
                     <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
                     <div>
                       <p className="text-sm font-medium">Shipped</p>
-                      <p className="text-xs text-gray-500">Order has been shipped</p>
+                      <p className="text-xs text-gray-500">
+                        Order has been shipped
+                      </p>
                     </div>
                   </div>
                 )}
-                
+
                 {order.status === 'delivered' && (
                   <div className="flex items-center gap-3">
                     <div className="w-2 h-2 bg-green-500 rounded-full"></div>
                     <div>
                       <p className="text-sm font-medium">Delivered</p>
-                      <p className="text-xs text-gray-500">Order has been delivered</p>
+                      <p className="text-xs text-gray-500">
+                        Order has been delivered
+                      </p>
                     </div>
                   </div>
                 )}
@@ -235,4 +261,4 @@ function OrderDetail() {
   )
 }
 
-export default OrderDetail 
+export default OrderDetail

--- a/client/pages/buyer/ProductDetail.tsx
+++ b/client/pages/buyer/ProductDetail.tsx
@@ -10,6 +10,7 @@ import { addToCartAtom, cartAtom } from '@/atoms/cartAtoms'
 import SectionTitle from '@/components/SectionTitle'
 import { toast } from 'sonner'
 import { ArrowLeft } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 function ProductDetail() {
   const { id } = useParams<{ id: string }>()
@@ -22,7 +23,7 @@ function ProductDetail() {
 
   const fetchData = async (idval: string | null) => {
     if (!idval) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<Product>(`/api/buyer/products/${idval}`)
@@ -45,10 +46,10 @@ function ProductDetail() {
     if (product) {
       try {
         // Check if product already exists in cart before adding
-        const existingItem = cart.find(item => item.productId === product.id)
-        
+        const existingItem = cart.find((item) => item.productId === product.id)
+
         await add(product)
-        
+
         if (existingItem) {
           toast.success(`${product.name} quantity updated in cart!`)
         } else {
@@ -60,20 +61,24 @@ function ProductDetail() {
     }
   }
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!product) return <div>Product not found.</div>
 
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4 mb-2">
-        <Button variant="outline" size="sm" onClick={() => navigate('/catalog')}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate('/catalog')}
+        >
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back to Catalog
         </Button>
         <SectionTitle>{product.name}</SectionTitle>
       </div>
-      
+
       <Card>
         <CardContent className="p-6">
           <div className="space-y-4">
@@ -81,7 +86,7 @@ function ProductDetail() {
               <h3 className="text-lg font-semibold">Description</h3>
               <p className="text-muted-foreground">{product.description}</p>
             </div>
-            
+
             <div>
               <h3 className="text-lg font-semibold">Price</h3>
               <p className="text-2xl font-bold text-green-600">
@@ -91,7 +96,7 @@ function ProductDetail() {
                 }).format(product.price)}
               </p>
             </div>
-            
+
             <Button onClick={handleAddToCart} className="w-full">
               Add to Cart
             </Button>

--- a/client/pages/seller/EditProduct.tsx
+++ b/client/pages/seller/EditProduct.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Textarea } from '@/components/ui/textarea'
+import { Spinner } from '@/components/ui/spinner'
 import { refreshSellerProductsAtom } from '@/atoms/sellerAtoms'
 
 function EditProduct() {
@@ -20,7 +21,7 @@ function EditProduct() {
 
   const fetchProduct = useCallback(async () => {
     if (!id) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<SellerProduct>(`/api/seller/products/${id}`)
@@ -39,13 +40,13 @@ function EditProduct() {
 
     setLoading(true)
     setError(null)
-    
+
     const formData = new FormData(e.currentTarget)
     const productData = {
       name: formData.get('name') as string,
       price: Number(formData.get('price')),
       description: formData.get('description') as string,
-      imageUrl: formData.get('imageUrl') as string || undefined,
+      imageUrl: (formData.get('imageUrl') as string) || undefined,
     }
 
     try {
@@ -55,7 +56,8 @@ function EditProduct() {
       navigate('/seller/dashboard')
     } catch (err: unknown) {
       console.error('Failed to update product:', err)
-      const errorMessage = err instanceof Error ? err.message : 'Failed to update product'
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to update product'
       setError(errorMessage)
     } finally {
       setLoading(false)
@@ -66,7 +68,7 @@ function EditProduct() {
     fetchProduct()
   }, [fetchProduct])
 
-  if (loading && !product) return <div>Loading...</div>
+  if (loading && !product) return <Spinner />
   if (error && !product) return <div className="text-red-600">{error}</div>
   if (!product) return <div>Product not found.</div>
 
@@ -83,24 +85,42 @@ function EditProduct() {
           </div>
           <div>
             <Label htmlFor="price">Price</Label>
-            <Input id="price" name="price" type="number" step="0.01" min="0" defaultValue={product.price} required />
+            <Input
+              id="price"
+              name="price"
+              type="number"
+              step="0.01"
+              min="0"
+              defaultValue={product.price}
+              required
+            />
           </div>
           <div>
             <Label htmlFor="description">Description</Label>
-            <Textarea id="description" name="description" rows={3} defaultValue={product.description || ''} />
+            <Textarea
+              id="description"
+              name="description"
+              rows={3}
+              defaultValue={product.description || ''}
+            />
           </div>
           <div>
             <Label htmlFor="imageUrl">Image URL (optional)</Label>
-            <Input id="imageUrl" name="imageUrl" type="url" defaultValue={product.imageUrl || ''} />
+            <Input
+              id="imageUrl"
+              name="imageUrl"
+              type="url"
+              defaultValue={product.imageUrl || ''}
+            />
           </div>
           {error && <div className="text-red-600">{error}</div>}
           <div className="flex gap-2">
             <Button type="submit" disabled={loading}>
               {loading ? 'Updating...' : 'Update Product'}
             </Button>
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
               onClick={() => navigate('/seller/dashboard')}
             >
               Cancel

--- a/client/pages/seller/MyProducts.tsx
+++ b/client/pages/seller/MyProducts.tsx
@@ -4,6 +4,7 @@ import { isAxiosError } from '@/lib/axios'
 import type { SellerProduct } from '@/types/Seller'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 function MyProducts() {
   const [products, setProducts] = useState<SellerProduct[]>([])
@@ -37,7 +38,7 @@ function MyProducts() {
     fetchData()
   }, [])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!products.length) return <div>No products yet.</div>
 

--- a/client/pages/seller/OrdersReceived.tsx
+++ b/client/pages/seller/OrdersReceived.tsx
@@ -4,6 +4,7 @@ import { isAxiosError } from '@/lib/axios'
 import type { Order } from '@/types/Seller'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 function OrdersReceived() {
   const [orders, setOrders] = useState<Order[]>([])
@@ -38,7 +39,7 @@ function OrdersReceived() {
     fetchData()
   }, [])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!orders.length) return <div>No orders yet.</div>
 

--- a/client/pages/seller/Payouts.tsx
+++ b/client/pages/seller/Payouts.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Plus, DollarSign, X } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 function Payouts() {
   const [payouts, setPayouts] = useState<SellerPayout[]>([])
@@ -42,13 +43,13 @@ function Payouts() {
     try {
       await axios.post('/api/seller/payouts', {
         amount,
-        bankAccount
+        bankAccount,
       })
-      
+
       // Refresh the payouts list
       await fetchData()
       setIsRequestModalOpen(false)
-      
+
       // Reset form
       e.currentTarget.reset()
     } catch (err) {
@@ -65,14 +66,18 @@ function Payouts() {
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'pending': return 'bg-yellow-100 text-yellow-800'
-      case 'processed': return 'bg-green-100 text-green-800'
-      case 'failed': return 'bg-red-100 text-red-800'
-      default: return 'bg-gray-100 text-gray-800'
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'processed':
+        return 'bg-green-100 text-green-800'
+      case 'failed':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
 
   return (
@@ -159,7 +164,9 @@ function Payouts() {
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
                   Payout #{payout.id}
-                  <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(payout.status || 'pending')}`}>
+                  <span
+                    className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(payout.status || 'pending')}`}
+                  >
                     {payout.status}
                   </span>
                 </CardTitle>
@@ -175,7 +182,9 @@ function Payouts() {
                   <div>
                     <span className="font-semibold">Date:</span>
                     <p className="text-sm text-gray-600">
-                      {payout.date ? new Date(payout.date).toLocaleDateString() : 'N/A'}
+                      {payout.date
+                        ? new Date(payout.date).toLocaleDateString()
+                        : 'N/A'}
                     </p>
                   </div>
                   {payout.createdAt && (

--- a/client/pages/seller/SellerDashboard.tsx
+++ b/client/pages/seller/SellerDashboard.tsx
@@ -5,6 +5,7 @@ import axios from '@/lib/axios'
 import type { SellerProduct, Order } from '@/types/Seller'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
 import { sellerProductsRefreshAtom } from '@/atoms/sellerAtoms'
 
 function SellerDashboard() {
@@ -19,7 +20,9 @@ function SellerDashboard() {
     setLoading(true)
     try {
       // Fetch seller products from the API
-      const productsRes = await axios.get<SellerProduct[]>('/api/seller/products')
+      const productsRes = await axios.get<SellerProduct[]>(
+        '/api/seller/products'
+      )
       setProducts(productsRes.data)
       // Fetch seller orders from the API
       const ordersRes = await axios.get<Order[]>('/api/seller/orders')
@@ -55,7 +58,7 @@ function SellerDashboard() {
     fetchData()
   }, [refreshCounter]) // Refresh when the counter changes
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
 
   return (
@@ -87,9 +90,7 @@ function SellerDashboard() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>My Products</CardTitle>
-          <Button onClick={handleCreateProduct}>
-            Create Product
-          </Button>
+          <Button onClick={handleCreateProduct}>Create Product</Button>
         </CardHeader>
         <CardContent>
           {products.length === 0 ? (
@@ -99,31 +100,42 @@ function SellerDashboard() {
           ) : (
             <div className="space-y-4">
               {products.map((product) => (
-                <div key={product.id} className="flex items-center justify-between p-4 border rounded-lg">
+                <div
+                  key={product.id}
+                  className="flex items-center justify-between p-4 border rounded-lg"
+                >
                   <div>
                     <h3 className="font-semibold">{product.name}</h3>
-                    <p className="text-sm text-muted-foreground">${product.price}</p>
+                    <p className="text-sm text-muted-foreground">
+                      ${product.price}
+                    </p>
                     {product.description && (
-                      <p className="text-sm text-muted-foreground mt-1">{product.description}</p>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {product.description}
+                      </p>
                     )}
                   </div>
                   <div className="flex gap-2">
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       size="sm"
-                      onClick={() => navigate(`/seller/view-product/${product.id}`)}
+                      onClick={() =>
+                        navigate(`/seller/view-product/${product.id}`)
+                      }
                     >
                       View
                     </Button>
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       size="sm"
-                      onClick={() => navigate(`/seller/edit-product/${product.id}`)}
+                      onClick={() =>
+                        navigate(`/seller/edit-product/${product.id}`)
+                      }
                     >
                       Edit
                     </Button>
-                    <Button 
-                      variant="destructive" 
+                    <Button
+                      variant="destructive"
                       size="sm"
                       onClick={() => handleDeleteProduct(product.id)}
                     >

--- a/client/pages/seller/ViewProduct.tsx
+++ b/client/pages/seller/ViewProduct.tsx
@@ -5,6 +5,7 @@ import type { SellerProduct } from '@/types/Seller'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 
 function ViewProduct() {
   const { id } = useParams<{ id: string }>()
@@ -15,7 +16,7 @@ function ViewProduct() {
 
   const fetchProduct = useCallback(async () => {
     if (!id) return
-    
+
     setLoading(true)
     try {
       const res = await axios.get<SellerProduct>(`/api/seller/products/${id}`)
@@ -32,7 +33,7 @@ function ViewProduct() {
     fetchProduct()
   }, [fetchProduct])
 
-  if (loading) return <div>Loading...</div>
+  if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!product) return <div>Product not found.</div>
 
@@ -41,14 +42,14 @@ function ViewProduct() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Product Details</h1>
         <div className="flex gap-2">
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             onClick={() => navigate(`/seller/edit-product/${product.id}`)}
           >
             Edit Product
           </Button>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             onClick={() => navigate('/seller/products')}
           >
             <ArrowLeft className="h-4 w-4 mr-2" />
@@ -64,27 +65,35 @@ function ViewProduct() {
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <h3 className="font-semibold text-sm text-muted-foreground">Price</h3>
+              <h3 className="font-semibold text-sm text-muted-foreground">
+                Price
+              </h3>
               <p className="text-lg font-bold">${product.price}</p>
             </div>
             <div>
-              <h3 className="font-semibold text-sm text-muted-foreground">Status</h3>
+              <h3 className="font-semibold text-sm text-muted-foreground">
+                Status
+              </h3>
               <p className="text-sm">{product.status}</p>
             </div>
           </div>
-          
+
           {product.description && (
             <div>
-              <h3 className="font-semibold text-sm text-muted-foreground">Description</h3>
+              <h3 className="font-semibold text-sm text-muted-foreground">
+                Description
+              </h3>
               <p className="text-sm">{product.description}</p>
             </div>
           )}
-          
+
           {product.imageUrl && (
             <div>
-              <h3 className="font-semibold text-sm text-muted-foreground">Image</h3>
-              <img 
-                src={product.imageUrl} 
+              <h3 className="font-semibold text-sm text-muted-foreground">
+                Image
+              </h3>
+              <img
+                src={product.imageUrl}
                 alt={product.name}
                 className="w-32 h-32 object-cover rounded-lg"
               />
@@ -96,4 +105,4 @@ function ViewProduct() {
   )
 }
 
-export default ViewProduct 
+export default ViewProduct


### PR DESCRIPTION
## Summary
- add reusable `Spinner` component with loader icon
- use `Spinner` in pages that previously returned plain `Loading...` text

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874e2bcaa1c832db8a9e46ca7e5a642