### PR TITLE
Add activation confirmation for sellers

### DIFF
--- a/client/pages/admin/ManageSellers.tsx
+++ b/client/pages/admin/ManageSellers.tsx
@@ -3,6 +3,15 @@ import { useNavigate } from 'react-router-dom'
 import axios from '@/lib/axios'
 import { DataTable } from '@/components/DataTable'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { AdminSeller } from '@/types/Admin'
 import { Eye } from 'lucide-react'
@@ -10,6 +19,10 @@ import { Eye } from 'lucide-react'
 function ManageSellers() {
   const [data, setData] = useState<AdminSeller[]>([])
   const [loading, setLoading] = useState(false)
+  const [target, setTarget] = useState<{
+    seller: AdminSeller
+    action: 'activate' | 'deactivate'
+  } | null>(null)
   const navigate = useNavigate()
 
   const fetchData = async () => {
@@ -71,13 +84,16 @@ function ManageSellers() {
               <Button
                 variant="destructive"
                 size="sm"
-                onClick={() => updateStatus(s, 'deactivate')}
+                onClick={() => setTarget({ seller: s, action: 'deactivate' })}
               >
                 Deactivate
               </Button>
             )}
             {s.status === 'inactive' && (
-              <Button size="sm" onClick={() => updateStatus(s, 'activate')}>
+              <Button
+                size="sm"
+                onClick={() => setTarget({ seller: s, action: 'activate' })}
+              >
                 Activate
               </Button>
             )}
@@ -89,7 +105,32 @@ function ManageSellers() {
     },
   ]
 
-  return <DataTable columns={columns} data={data} isLoading={loading} />
+  return (
+    <>
+      <DataTable columns={columns} data={data} isLoading={loading} />
+      <AlertDialog open={!!target} onOpenChange={(o) => !o && setTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {target?.action === 'activate' ? 'Activate' : 'Deactivate'} this
+              seller?
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (target) updateStatus(target.seller, target.action)
+                setTarget(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
 }
 
 export default ManageSellers

--- a/client/pages/admin/ViewSeller.tsx
+++ b/client/pages/admin/ViewSeller.tsx
@@ -4,6 +4,15 @@ import axios from '@/lib/axios'
 import type { Seller } from '@/server/schema'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { ArrowLeft } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 
@@ -13,6 +22,9 @@ function ViewSeller() {
   const [seller, setSeller] = useState<Seller | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [targetAction, setTargetAction] = useState<
+    'activate' | 'deactivate' | null
+  >(null)
 
   const fetchSeller = useCallback(async () => {
     if (!id) return
@@ -63,110 +75,138 @@ function ViewSeller() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="flex items-center gap-4 mb-6">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => navigate('/admin/sellers')}
-        >
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Sellers
-        </Button>
-        <h1 className="text-2xl font-bold">Seller Details</h1>
-      </div>
+    <>
+      <div className="max-w-4xl mx-auto p-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate('/admin/sellers')}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Sellers
+          </Button>
+          <h1 className="text-2xl font-bold">Seller Details</h1>
+        </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              {seller.name}
-              <span
-                className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(seller.status || 'inactive')}`}
-              >
-                {seller.status}
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {seller.logo && (
-              <div className="aspect-square w-32 overflow-hidden rounded-lg">
-                <img
-                  src={seller.logo}
-                  alt={seller.name}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-            )}
-
-            <div className="space-y-2">
-              <div>
-                <span className="font-semibold">Seller ID:</span> {seller.id}
-              </div>
-              <div>
-                <span className="font-semibold">User ID:</span> {seller.userId}
-              </div>
-              {seller.bio && (
-                <div>
-                  <span className="font-semibold">Bio:</span>
-                  <p className="mt-1 text-sm text-gray-600">{seller.bio}</p>
-                </div>
-              )}
-              {seller.contact && (
-                <div>
-                  <span className="font-semibold">Contact:</span>
-                  <p className="mt-1 text-sm text-gray-600">{seller.contact}</p>
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Admin Actions</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {seller.status === 'pending' && (
-              <>
-                <Button
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('approve')}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                {seller.name}
+                <span
+                  className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(seller.status || 'inactive')}`}
                 >
-                  Approve Seller
-                </Button>
+                  {seller.status}
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {seller.logo && (
+                <div className="aspect-square w-32 overflow-hidden rounded-lg">
+                  <img
+                    src={seller.logo}
+                    alt={seller.name}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <div>
+                  <span className="font-semibold">Seller ID:</span> {seller.id}
+                </div>
+                <div>
+                  <span className="font-semibold">User ID:</span>{' '}
+                  {seller.userId}
+                </div>
+                {seller.bio && (
+                  <div>
+                    <span className="font-semibold">Bio:</span>
+                    <p className="mt-1 text-sm text-gray-600">{seller.bio}</p>
+                  </div>
+                )}
+                {seller.contact && (
+                  <div>
+                    <span className="font-semibold">Contact:</span>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {seller.contact}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Admin Actions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {seller.status === 'pending' && (
+                <>
+                  <Button
+                    className="w-full"
+                    onClick={() => handleStatusUpdate('approve')}
+                  >
+                    Approve Seller
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={() => handleStatusUpdate('reject')}
+                  >
+                    Reject Seller
+                  </Button>
+                </>
+              )}
+
+              {seller.status === 'active' && (
                 <Button
                   variant="destructive"
                   className="w-full"
-                  onClick={() => handleStatusUpdate('reject')}
+                  onClick={() => setTargetAction('deactivate')}
                 >
-                  Reject Seller
+                  Deactivate Seller
                 </Button>
-              </>
-            )}
+              )}
 
-            {seller.status === 'active' && (
-              <Button
-                variant="destructive"
-                className="w-full"
-                onClick={() => handleStatusUpdate('deactivate')}
-              >
-                Deactivate Seller
-              </Button>
-            )}
-
-            {seller.status === 'inactive' && (
-              <Button
-                className="w-full"
-                onClick={() => handleStatusUpdate('activate')}
-              >
-                Activate Seller
-              </Button>
-            )}
-          </CardContent>
-        </Card>
+              {seller.status === 'inactive' && (
+                <Button
+                  className="w-full"
+                  onClick={() => setTargetAction('activate')}
+                >
+                  Activate Seller
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </div>
-    </div>
+      <AlertDialog
+        open={!!targetAction}
+        onOpenChange={(o) => !o && setTargetAction(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {targetAction === 'activate' ? 'Activate' : 'Deactivate'} seller?
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (targetAction) handleStatusUpdate(targetAction)
+                setTargetAction(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- add AlertDialog confirmation UI for activating and deactivating sellers in `ManageSellers` page
- add same confirmation in `ViewSeller` page

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874ed645dfc832d90a69efb8b54276f