### PR TITLE
Add confirmation popups to buyer pages

### DIFF
--- a/client/pages/buyer/Cart.tsx
+++ b/client/pages/buyer/Cart.tsx
@@ -1,5 +1,11 @@
 import { useAtom, useSetAtom } from 'jotai'
-import { cartAtom, removeFromCartAtom, updateCartQuantityAtom, cartTotalAtom, loadCartAtom } from '@/atoms/cartAtoms'
+import {
+  cartAtom,
+  removeFromCartAtom,
+  updateCartQuantityAtom,
+  cartTotalAtom,
+  loadCartAtom,
+} from '@/atoms/cartAtoms'
 import CartItem from '@/components/CartItem'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -8,7 +14,22 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { ShoppingCart, Package, AlertCircle, ArrowRight, Trash2 } from 'lucide-react'
+import {
+  ShoppingCart,
+  Package,
+  AlertCircle,
+  ArrowRight,
+  Trash2,
+} from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 function Cart() {
   const [items] = useAtom(cartAtom)
@@ -19,6 +40,8 @@ function Cart() {
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [targetRemoveId, setTargetRemoveId] = useState<number | null>(null)
+  const [confirmClear, setConfirmClear] = useState(false)
 
   useEffect(() => {
     const fetchCart = async () => {
@@ -45,7 +68,7 @@ function Cart() {
   }
 
   const handleClearCart = () => {
-    items.forEach(item => remove(item.productId))
+    items.forEach((item) => remove(item.productId))
   }
 
   if (loading) {
@@ -120,11 +143,11 @@ function Cart() {
             </Badge>
           </div>
         </div>
-        
-        <Button 
-          variant="outline" 
+
+        <Button
+          variant="outline"
           size="sm"
-          onClick={handleClearCart}
+          onClick={() => setConfirmClear(true)}
           className="text-destructive hover:text-destructive"
         >
           <Trash2 className="mr-2 h-4 w-4" />
@@ -139,7 +162,7 @@ function Cart() {
             key={item.id}
             product={item.product}
             quantity={item.quantity}
-            onRemove={() => remove(item.productId)}
+            onRemove={() => setTargetRemoveId(item.productId)}
             onChange={(q) => update({ productId: item.productId, quantity: q })}
           />
         ))}
@@ -161,11 +184,13 @@ function Cart() {
           </div>
           <div className="flex justify-between items-center py-2">
             <span className="text-lg font-semibold">Total</span>
-            <span className="text-xl font-bold text-primary">{formatPrice(total)}</span>
+            <span className="text-xl font-bold text-primary">
+              {formatPrice(total)}
+            </span>
           </div>
-          
-          <Button 
-            onClick={() => navigate('/buyer/checkout')} 
+
+          <Button
+            onClick={() => navigate('/buyer/checkout')}
             className="w-full"
             size="lg"
           >
@@ -174,6 +199,48 @@ function Cart() {
           </Button>
         </CardContent>
       </Card>
+      <AlertDialog
+        open={confirmClear}
+        onOpenChange={(o) => !o && setConfirmClear(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear all items from cart?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                handleClearCart()
+                setConfirmClear(false)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <AlertDialog
+        open={targetRemoveId !== null}
+        onOpenChange={(o) => !o && setTargetRemoveId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this item from cart?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (targetRemoveId !== null) remove(targetRemoveId)
+                setTargetRemoveId(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/client/pages/buyer/Catalog.tsx
+++ b/client/pages/buyer/Catalog.tsx
@@ -14,6 +14,15 @@ import { addToCartAtom, cartAtom } from '@/atoms/cartAtoms'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Search, Package, AlertCircle, ShoppingCart } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 function Catalog() {
   const [products, setProducts] = useState<Product[]>([])
@@ -24,6 +33,7 @@ function Catalog() {
   const add = useSetAtom(addToCartAtom)
   const [cart] = useAtom(cartAtom)
   const navigate = useNavigate()
+  const [targetProduct, setTargetProduct] = useState<Product | null>(null)
 
   const fetchData = async () => {
     setLoading(true)
@@ -44,9 +54,11 @@ function Catalog() {
   }, [])
 
   useEffect(() => {
-    const filtered = products.filter(product =>
-      product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (product.description && product.description.toLowerCase().includes(searchTerm.toLowerCase()))
+    const filtered = products.filter(
+      (product) =>
+        product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (product.description &&
+          product.description.toLowerCase().includes(searchTerm.toLowerCase()))
     )
     setFilteredProducts(filtered)
   }, [searchTerm, products])
@@ -54,10 +66,10 @@ function Catalog() {
   const handleAddToCart = async (product: Product) => {
     try {
       // Check if product already exists in cart before adding
-      const existingItem = cart.find(item => item.productId === product.id)
-      
+      const existingItem = cart.find((item) => item.productId === product.id)
+
       await add(product)
-      
+
       if (existingItem) {
         toast.success(`${product.name} quantity updated in cart!`)
       } else {
@@ -69,7 +81,7 @@ function Catalog() {
   }
 
   const getStatusCount = () => {
-    const activeProducts = products.filter(p => p.status === 'active')
+    const activeProducts = products.filter((p) => p.status === 'active')
     return activeProducts.length
   }
 
@@ -123,10 +135,12 @@ function Catalog() {
               <ShoppingCart className="h-4 w-4" />
               <span>{cart.length} items in cart</span>
             </div>
-            <Badge variant="secondary">{getStatusCount()} active products</Badge>
+            <Badge variant="secondary">
+              {getStatusCount()} active products
+            </Badge>
           </div>
         </div>
-        
+
         {/* Search */}
         <div className="relative w-full sm:w-80">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -148,8 +162,8 @@ function Catalog() {
             <p className="text-muted-foreground text-center">
               Try adjusting your search terms or browse all products
             </p>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               onClick={() => setSearchTerm('')}
               className="mt-4"
             >
@@ -161,7 +175,9 @@ function Catalog() {
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
             <Package className="h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No products available</h3>
+            <h3 className="text-lg font-semibold mb-2">
+              No products available
+            </h3>
             <p className="text-muted-foreground text-center">
               Check back later for new products
             </p>
@@ -173,12 +189,33 @@ function Catalog() {
             <ProductCard
               key={product.id}
               product={product}
-              onAdd={() => handleAddToCart(product)}
+              onAdd={() => setTargetProduct(product)}
               onView={() => navigate(`/buyer/product/${product.id}`)}
             />
           ))}
         </div>
       )}
+      <AlertDialog
+        open={!!targetProduct}
+        onOpenChange={(o) => !o && setTargetProduct(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Add this item to cart?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (targetProduct) handleAddToCart(targetProduct)
+                setTargetProduct(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/client/pages/buyer/Checkout.tsx
+++ b/client/pages/buyer/Checkout.tsx
@@ -4,19 +4,35 @@ import { cartAtom } from '@/atoms/cartAtoms'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import axios from '@/lib/axios'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 function Checkout() {
   const cart = useAtomValue(cartAtom)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [confirmCheckout, setConfirmCheckout] = useState(false)
 
-  const total = cart.reduce((sum, item) => sum + (item.product.price * item.quantity), 0)
+  const total = cart.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0
+  )
 
   const handleCheckout = async () => {
     setLoading(true)
     setError(null)
     try {
-      const items = cart.map(item => ({ productId: item.product.id, quantity: item.quantity }))
+      const items = cart.map((item) => ({
+        productId: item.product.id,
+        quantity: item.quantity,
+      }))
       // For demo, use a static shipping address and payment method
       await axios.post('/api/buyer/orders', {
         items,
@@ -37,41 +53,68 @@ function Checkout() {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Checkout</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          {cart.map((item) => (
-            <div key={item.id} className="flex justify-between">
-              <span>{item.product.name}</span>
-              <span>
-                {new Intl.NumberFormat('id-ID', {
-                  style: 'currency',
-                  currency: 'IDR',
-                }).format(item.product.price * item.quantity)}
-              </span>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Checkout</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {cart.map((item) => (
+              <div key={item.id} className="flex justify-between">
+                <span>{item.product.name}</span>
+                <span>
+                  {new Intl.NumberFormat('id-ID', {
+                    style: 'currency',
+                    currency: 'IDR',
+                  }).format(item.product.price * item.quantity)}
+                </span>
+              </div>
+            ))}
+            <div className="border-t pt-4">
+              <div className="flex justify-between font-bold">
+                <span>Total:</span>
+                <span>
+                  {new Intl.NumberFormat('id-ID', {
+                    style: 'currency',
+                    currency: 'IDR',
+                  }).format(total)}
+                </span>
+              </div>
             </div>
-          ))}
-          <div className="border-t pt-4">
-            <div className="flex justify-between font-bold">
-              <span>Total:</span>
-              <span>
-                {new Intl.NumberFormat('id-ID', {
-                  style: 'currency',
-                  currency: 'IDR',
-                }).format(total)}
-              </span>
-            </div>
+            {error && <div className="text-red-600">{error}</div>}
+            <Button
+              onClick={() => setConfirmCheckout(true)}
+              disabled={loading}
+              className="w-full"
+            >
+              {loading ? 'Processing...' : 'Place Order'}
+            </Button>
           </div>
-          {error && <div className="text-red-600">{error}</div>}
-          <Button onClick={handleCheckout} disabled={loading} className="w-full">
-            {loading ? 'Processing...' : 'Place Order'}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+      <AlertDialog
+        open={confirmCheckout}
+        onOpenChange={(o) => !o && setConfirmCheckout(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Place this order?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                handleCheckout()
+                setConfirmCheckout(false)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }
 

--- a/client/pages/buyer/ProductDetail.tsx
+++ b/client/pages/buyer/ProductDetail.tsx
@@ -10,6 +10,15 @@ import { addToCartAtom, cartAtom } from '@/atoms/cartAtoms'
 import SectionTitle from '@/components/SectionTitle'
 import { toast } from 'sonner'
 import { ArrowLeft } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Spinner } from '@/components/ui/spinner'
 
 function ProductDetail() {
@@ -20,6 +29,7 @@ function ProductDetail() {
   const [error, setError] = useState<string | null>(null)
   const add = useSetAtom(addToCartAtom)
   const [cart] = useAtom(cartAtom)
+  const [confirmAdd, setConfirmAdd] = useState(false)
 
   const fetchData = async (idval: string | null) => {
     if (!idval) return
@@ -97,12 +107,33 @@ function ProductDetail() {
               </p>
             </div>
 
-            <Button onClick={handleAddToCart} className="w-full">
+            <Button onClick={() => setConfirmAdd(true)} className="w-full">
               Add to Cart
             </Button>
           </div>
         </CardContent>
       </Card>
+      <AlertDialog
+        open={confirmAdd}
+        onOpenChange={(o) => !o && setConfirmAdd(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Add this item to cart?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                handleAddToCart()
+                setConfirmAdd(false)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- ask for confirmation when adding a product from catalog
- confirm add to cart from detail page
- confirm removing and clearing cart
- confirm checkout before placing an order

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874f1212890832d83645c06b4086b81