### PR TITLE
Prevent banned user login

### DIFF
--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -122,6 +122,13 @@ export async function loginByUsernamePassword(data: LoginRequest | unknown): Pro
   }
 
   const user = rows[0];
+
+  // Prevent banned users from logging in
+  if (user.status === 'banned') {
+    return {
+      MESSAGE: 'Your account has been banned. Please contact an admin to be unbanned'
+    };
+  }
   const token = generateToken(user.id);
   const publicUser = createPublicUser(user);
   // For demo, use current time for createdAt/updatedAt

--- a/server/handlers.ts
+++ b/server/handlers.ts
@@ -175,6 +175,9 @@ export const handlers = [
         if (result.MESSAGE.includes('Invalid username or password')) {
           return res(ctx.status(401), ctx.json(result));
         }
+        if (result.MESSAGE.includes('banned')) {
+          return res(ctx.status(403), ctx.json(result));
+        }
         return res(ctx.status(500), ctx.json(result));
       }
       


### PR DESCRIPTION
## Summary
- reject login attempts when user status is `banned`
- return `403` with a helpful message in the login handler
- document banned login check in code

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874f2182c14832d911797fb8d6e807c