### PR TITLE
Add confirmation dialogs to admin actions

### DIFF
--- a/client/pages/admin/ManageProducts.tsx
+++ b/client/pages/admin/ManageProducts.tsx
@@ -3,6 +3,15 @@ import { useNavigate } from 'react-router-dom'
 import axios from '@/lib/axios'
 import { DataTable } from '@/components/DataTable'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { AdminProduct } from '@/types/Admin'
 import { Eye } from 'lucide-react'
@@ -11,6 +20,10 @@ import { formatIDR } from '@/lib/utils'
 function ManageProducts() {
   const [data, setData] = useState<AdminProduct[]>([])
   const [loading, setLoading] = useState(false)
+  const [target, setTarget] = useState<{
+    product: AdminProduct
+    action: 'approve' | 'reject' | 'flag' | 'remove' | 'unflag'
+  } | null>(null)
   const navigate = useNavigate()
 
   const fetchData = async () => {
@@ -62,13 +75,16 @@ function ManageProducts() {
             </Button>
             {p.status === 'pending' && (
               <>
-                <Button size="sm" onClick={() => updateStatus(p, 'approve')}>
+                <Button
+                  size="sm"
+                  onClick={() => setTarget({ product: p, action: 'approve' })}
+                >
                   Approve
                 </Button>
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => updateStatus(p, 'reject')}
+                  onClick={() => setTarget({ product: p, action: 'reject' })}
                 >
                   Reject
                 </Button>
@@ -79,14 +95,14 @@ function ManageProducts() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => updateStatus(p, 'flag')}
+                  onClick={() => setTarget({ product: p, action: 'flag' })}
                 >
                   Flag
                 </Button>
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => updateStatus(p, 'remove')}
+                  onClick={() => setTarget({ product: p, action: 'remove' })}
                 >
                   Remove
                 </Button>
@@ -100,7 +116,43 @@ function ManageProducts() {
     },
   ]
 
-  return <DataTable columns={columns} data={data} isLoading={loading} />
+  return (
+    <>
+      <DataTable columns={columns} data={data} isLoading={loading} />
+      <AlertDialog open={!!target} onOpenChange={(o) => !o && setTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {(() => {
+                if (!target) return ''
+                const label =
+                  target.action === 'unflag'
+                    ? 'Unflag'
+                    : target.action.charAt(0).toUpperCase() +
+                      target.action.slice(1)
+                return `${label} this product?`
+              })()}
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (target)
+                  updateStatus(
+                    target.product,
+                    target.action === 'unflag' ? 'approve' : target.action
+                  )
+                setTarget(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
 }
 
 export default ManageProducts

--- a/client/pages/admin/ManageSellers.tsx
+++ b/client/pages/admin/ManageSellers.tsx
@@ -21,7 +21,7 @@ function ManageSellers() {
   const [loading, setLoading] = useState(false)
   const [target, setTarget] = useState<{
     seller: AdminSeller
-    action: 'activate' | 'deactivate'
+    action: 'activate' | 'deactivate' | 'approve' | 'reject'
   } | null>(null)
   const navigate = useNavigate()
 
@@ -68,13 +68,16 @@ function ManageSellers() {
             </Button>
             {s.status === 'pending' && (
               <>
-                <Button size="sm" onClick={() => updateStatus(s, 'approve')}>
+                <Button
+                  size="sm"
+                  onClick={() => setTarget({ seller: s, action: 'approve' })}
+                >
                   Approve
                 </Button>
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => updateStatus(s, 'reject')}
+                  onClick={() => setTarget({ seller: s, action: 'reject' })}
                 >
                   Reject
                 </Button>
@@ -112,8 +115,13 @@ function ManageSellers() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {target?.action === 'activate' ? 'Activate' : 'Deactivate'} this
-              seller?
+              {`${
+                target?.action
+                  ? target.action.charAt(0).toUpperCase() +
+                    target.action.slice(1)
+                  : ''
+              }`}{' '}
+              this seller?
             </AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/client/pages/admin/Reports.tsx
+++ b/client/pages/admin/Reports.tsx
@@ -2,12 +2,22 @@ import { useEffect, useState } from 'react'
 import axios from '@/lib/axios'
 import { DataTable } from '@/components/DataTable'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { AdminReport } from '@/types/Admin'
 
 function Reports() {
   const [data, setData] = useState<AdminReport[]>([])
   const [loading, setLoading] = useState(false)
+  const [target, setTarget] = useState<AdminReport | null>(null)
 
   const fetchData = async () => {
     setLoading(true)
@@ -45,7 +55,7 @@ function Reports() {
       cell: ({ row }) => {
         const rep = row.original
         return rep.status === 'open' ? (
-          <Button size="sm" onClick={() => resolve(rep)}>
+          <Button size="sm" onClick={() => setTarget(rep)}>
             Resolve
           </Button>
         ) : null
@@ -55,7 +65,29 @@ function Reports() {
     },
   ]
 
-  return <DataTable columns={columns} data={data} isLoading={loading} />
+  return (
+    <>
+      <DataTable columns={columns} data={data} isLoading={loading} />
+      <AlertDialog open={!!target} onOpenChange={(o) => !o && setTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Resolve this report?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (target) resolve(target)
+                setTarget(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
 }
 
 export default Reports

--- a/client/pages/admin/ViewProduct.tsx
+++ b/client/pages/admin/ViewProduct.tsx
@@ -3,6 +3,15 @@ import { useParams, useNavigate } from 'react-router-dom'
 import axios from '@/lib/axios'
 import type { Product } from '@/types/Product'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
@@ -14,6 +23,9 @@ function ViewProduct() {
   const [product, setProduct] = useState<Product | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [targetAction, setTargetAction] = useState<
+    'approve' | 'reject' | 'flag' | 'remove' | 'unflag' | null
+  >(null)
 
   const fetchProduct = useCallback(async () => {
     if (!id) return
@@ -66,126 +78,162 @@ function ViewProduct() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="flex items-center gap-4 mb-6">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => navigate('/admin/products')}
-        >
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Products
-        </Button>
-        <h1 className="text-2xl font-bold">Product Details</h1>
-      </div>
+    <>
+      <div className="max-w-4xl mx-auto p-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate('/admin/products')}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Products
+          </Button>
+          <h1 className="text-2xl font-bold">Product Details</h1>
+        </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              {product.name}
-              <span
-                className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(product.status || 'inactive')}`}
-              >
-                {product.status}
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {product.imageUrl && (
-              <div className="aspect-square overflow-hidden rounded-lg">
-                <img
-                  src={product.imageUrl}
-                  alt={product.name}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-            )}
-
-            <div className="space-y-2">
-              <div>
-                <span className="font-semibold">Price:</span>{' '}
-                {formatIDR(product.price)}
-              </div>
-              <div>
-                <span className="font-semibold">Seller ID:</span>{' '}
-                {product.sellerId}
-              </div>
-              {product.description && (
-                <div>
-                  <span className="font-semibold">Description:</span>
-                  <p className="mt-1 text-sm text-gray-600">
-                    {product.description}
-                  </p>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                {product.name}
+                <span
+                  className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(product.status || 'inactive')}`}
+                >
+                  {product.status}
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {product.imageUrl && (
+                <div className="aspect-square overflow-hidden rounded-lg">
+                  <img
+                    src={product.imageUrl}
+                    alt={product.name}
+                    className="w-full h-full object-cover"
+                  />
                 </div>
               )}
-            </div>
-          </CardContent>
-        </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Admin Actions</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {product.status === 'pending' && (
-              <>
-                <Button
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('approve')}
-                >
-                  Approve Product
-                </Button>
-                <Button
-                  variant="destructive"
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('reject')}
-                >
-                  Reject Product
-                </Button>
-              </>
-            )}
+              <div className="space-y-2">
+                <div>
+                  <span className="font-semibold">Price:</span>{' '}
+                  {formatIDR(product.price)}
+                </div>
+                <div>
+                  <span className="font-semibold">Seller ID:</span>{' '}
+                  {product.sellerId}
+                </div>
+                {product.description && (
+                  <div>
+                    <span className="font-semibold">Description:</span>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {product.description}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
 
-            {product.status === 'active' && (
-              <>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('flag')}
-                >
-                  Flag Product
-                </Button>
-                <Button
-                  variant="destructive"
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('remove')}
-                >
-                  Remove Product
-                </Button>
-              </>
-            )}
+          <Card>
+            <CardHeader>
+              <CardTitle>Admin Actions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {product.status === 'pending' && (
+                <>
+                  <Button
+                    className="w-full"
+                    onClick={() => setTargetAction('approve')}
+                  >
+                    Approve Product
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={() => setTargetAction('reject')}
+                  >
+                    Reject Product
+                  </Button>
+                </>
+              )}
 
-            {product.status === 'flagged' && (
-              <>
-                <Button
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('approve')}
-                >
-                  Unflag Product
-                </Button>
-                <Button
-                  variant="destructive"
-                  className="w-full"
-                  onClick={() => handleStatusUpdate('remove')}
-                >
-                  Remove Product
-                </Button>
-              </>
-            )}
-          </CardContent>
-        </Card>
+              {product.status === 'active' && (
+                <>
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => setTargetAction('flag')}
+                  >
+                    Flag Product
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={() => setTargetAction('remove')}
+                  >
+                    Remove Product
+                  </Button>
+                </>
+              )}
+
+              {product.status === 'flagged' && (
+                <>
+                  <Button
+                    className="w-full"
+                    onClick={() => setTargetAction('unflag')}
+                  >
+                    Unflag Product
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={() => setTargetAction('remove')}
+                  >
+                    Remove Product
+                  </Button>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </div>
-    </div>
+      <AlertDialog
+        open={!!targetAction}
+        onOpenChange={(o) => !o && setTargetAction(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {(() => {
+                if (!targetAction) return ''
+                const label =
+                  targetAction === 'unflag'
+                    ? 'Unflag'
+                    : targetAction.charAt(0).toUpperCase() +
+                      targetAction.slice(1)
+                return `${label} product?`
+              })()}
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (targetAction)
+                  handleStatusUpdate(
+                    targetAction === 'unflag' ? 'approve' : targetAction
+                  )
+                setTargetAction(null)
+              }}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }
 

--- a/client/pages/admin/ViewSeller.tsx
+++ b/client/pages/admin/ViewSeller.tsx
@@ -23,7 +23,7 @@ function ViewSeller() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [targetAction, setTargetAction] = useState<
-    'activate' | 'deactivate' | null
+    'activate' | 'deactivate' | 'approve' | 'reject' | null
   >(null)
 
   const fetchSeller = useCallback(async () => {
@@ -147,14 +147,14 @@ function ViewSeller() {
                 <>
                   <Button
                     className="w-full"
-                    onClick={() => handleStatusUpdate('approve')}
+                    onClick={() => setTargetAction('approve')}
                   >
                     Approve Seller
                   </Button>
                   <Button
                     variant="destructive"
                     className="w-full"
-                    onClick={() => handleStatusUpdate('reject')}
+                    onClick={() => setTargetAction('reject')}
                   >
                     Reject Seller
                   </Button>
@@ -190,7 +190,10 @@ function ViewSeller() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {targetAction === 'activate' ? 'Activate' : 'Deactivate'} seller?
+              {targetAction
+                ? `${targetAction.charAt(0).toUpperCase()}${targetAction.slice(1)}`
+                : ''}{' '}
+              seller?
             </AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/client/pages/admin/ViewUser.tsx
+++ b/client/pages/admin/ViewUser.tsx
@@ -3,6 +3,15 @@ import { useParams, useNavigate } from 'react-router-dom'
 import axios from '@/lib/axios'
 import type { User } from '@/server/schema'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
@@ -13,6 +22,7 @@ function ViewUser() {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [confirm, setConfirm] = useState(false)
 
   const fetchUser = useCallback(async () => {
     if (!id) return
@@ -76,99 +86,122 @@ function ViewUser() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="flex items-center gap-4 mb-6">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => navigate('/admin/users')}
-        >
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Users
-        </Button>
-        <h1 className="text-2xl font-bold">User Details</h1>
+    <>
+      <div className="max-w-4xl mx-auto p-6">
+        <div className="flex items-center gap-4 mb-6">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate('/admin/users')}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Users
+          </Button>
+          <h1 className="text-2xl font-bold">User Details</h1>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                {user.name}
+                <div className="flex gap-2">
+                  <span
+                    className={`px-2 py-1 rounded-full text-xs font-medium ${getRoleColor(user.role || 'buyer')}`}
+                  >
+                    {user.role}
+                  </span>
+                  <span
+                    className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status || 'inactive')}`}
+                  >
+                    {user.status}
+                  </span>
+                </div>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <div>
+                  <span className="font-semibold">User ID:</span> {user.id}
+                </div>
+                <div>
+                  <span className="font-semibold">Username:</span>{' '}
+                  {user.username}
+                </div>
+                <div>
+                  <span className="font-semibold">Name:</span> {user.name}
+                </div>
+                <div>
+                  <span className="font-semibold">Role:</span> {user.role}
+                </div>
+                <div>
+                  <span className="font-semibold">Status:</span> {user.status}
+                </div>
+                {user.createdAt && (
+                  <div>
+                    <span className="font-semibold">Created:</span>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {new Date(user.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                )}
+                {user.updatedAt && (
+                  <div>
+                    <span className="font-semibold">Last Updated:</span>
+                    <p className="mt-1 text-sm text-gray-600">
+                      {new Date(user.updatedAt).toLocaleString()}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Admin Actions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button
+                variant={user.status === 'banned' ? 'secondary' : 'destructive'}
+                className="w-full"
+                onClick={() => setConfirm(true)}
+              >
+                {user.status === 'banned' ? 'Unban User' : 'Ban User'}
+              </Button>
+
+              <div className="text-sm text-gray-600 mt-4">
+                <p>
+                  <strong>Note:</strong> Banning a user will prevent them from
+                  accessing the platform.
+                </p>
+                <p className="mt-2">Unbanning will restore their access.</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              {user.name}
-              <div className="flex gap-2">
-                <span
-                  className={`px-2 py-1 rounded-full text-xs font-medium ${getRoleColor(user.role || 'buyer')}`}
-                >
-                  {user.role}
-                </span>
-                <span
-                  className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status || 'inactive')}`}
-                >
-                  {user.status}
-                </span>
-              </div>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <div>
-                <span className="font-semibold">User ID:</span> {user.id}
-              </div>
-              <div>
-                <span className="font-semibold">Username:</span> {user.username}
-              </div>
-              <div>
-                <span className="font-semibold">Name:</span> {user.name}
-              </div>
-              <div>
-                <span className="font-semibold">Role:</span> {user.role}
-              </div>
-              <div>
-                <span className="font-semibold">Status:</span> {user.status}
-              </div>
-              {user.createdAt && (
-                <div>
-                  <span className="font-semibold">Created:</span>
-                  <p className="mt-1 text-sm text-gray-600">
-                    {new Date(user.createdAt).toLocaleString()}
-                  </p>
-                </div>
-              )}
-              {user.updatedAt && (
-                <div>
-                  <span className="font-semibold">Last Updated:</span>
-                  <p className="mt-1 text-sm text-gray-600">
-                    {new Date(user.updatedAt).toLocaleString()}
-                  </p>
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Admin Actions</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <Button
-              variant={user.status === 'banned' ? 'secondary' : 'destructive'}
-              className="w-full"
-              onClick={handleToggleBan}
+      <AlertDialog open={confirm} onOpenChange={(o) => !o && setConfirm(false)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {user?.status === 'banned' ? 'Unban' : 'Ban'} this user?
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                handleToggleBan()
+                setConfirm(false)
+              }}
             >
-              {user.status === 'banned' ? 'Unban User' : 'Ban User'}
-            </Button>
-
-            <div className="text-sm text-gray-600 mt-4">
-              <p>
-                <strong>Note:</strong> Banning a user will prevent them from
-                accessing the platform.
-              </p>
-              <p className="mt-2">Unbanning will restore their access.</p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- add AlertDialog confirmation for product actions in ManageProducts
- confirm seller status updates in ManageSellers
- add resolve confirmation for Reports
- prompt on ban/unban from ViewUser
- add confirmation on seller actions in ViewSeller
- require confirmation on product actions in ViewProduct

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6874f1155f38832d8e7f9ba62539a290