### PR TITLE
Fix admin badge colors

### DIFF
--- a/client/pages/admin/ManageUsers.tsx
+++ b/client/pages/admin/ManageUsers.tsx
@@ -23,29 +23,29 @@ function ManageUsers() {
   const [target, setTarget] = useState<AdminUser | null>(null)
   const navigate = useNavigate()
 
-  const getRoleBadgeVariant = (role: string) => {
+  const getRoleBadgeClass = (role: string) => {
     switch (role) {
       case 'admin':
-        return 'destructive'
+        return 'bg-purple-100 text-purple-800'
       case 'seller':
-        return 'secondary'
+        return 'bg-blue-100 text-blue-800'
       case 'buyer':
-        return 'default'
+        return 'bg-green-100 text-green-800'
       default:
-        return 'outline'
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
-  const getStatusBadgeVariant = (status: string) => {
+  const getStatusBadgeClass = (status: string) => {
     switch (status) {
       case 'active':
-        return 'default'
+        return 'bg-green-100 text-green-800'
       case 'banned':
-        return 'destructive'
+        return 'bg-red-100 text-red-800'
       case 'inactive':
-        return 'secondary'
+        return 'bg-gray-100 text-gray-800'
       default:
-        return 'outline'
+        return 'bg-gray-100 text-gray-800'
     }
   }
 
@@ -76,8 +76,10 @@ function ManageUsers() {
       header: 'Role',
       cell: ({ row }) => (
         <Badge
-          variant={getRoleBadgeVariant(row.original.role || 'buyer')}
-          className="capitalize"
+          variant="secondary"
+          className={`capitalize rounded-full ${getRoleBadgeClass(
+            row.original.role || 'buyer'
+          )}`}
         >
           {row.original.role}
         </Badge>
@@ -89,8 +91,10 @@ function ManageUsers() {
       header: 'Status',
       cell: ({ row }) => (
         <Badge
-          variant={getStatusBadgeVariant(row.original.status || 'active')}
-          className="capitalize"
+          variant="secondary"
+          className={`capitalize rounded-full ${getStatusBadgeClass(
+            row.original.status || 'active'
+          )}`}
         >
           {row.original.status}
         </Badge>

--- a/client/pages/admin/ViewUser.tsx
+++ b/client/pages/admin/ViewUser.tsx
@@ -15,6 +15,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
+import { Badge } from '@/components/ui/badge'
 
 function ViewUser() {
   const { id } = useParams<{ id: string }>()
@@ -59,7 +60,7 @@ function ViewUser() {
   if (error) return <div className="text-red-600">{error}</div>
   if (!user) return <div>User not found.</div>
 
-  const getStatusColor = (status: string) => {
+  const getStatusBadgeClass = (status: string) => {
     switch (status) {
       case 'active':
         return 'bg-green-100 text-green-800'
@@ -72,7 +73,7 @@ function ViewUser() {
     }
   }
 
-  const getRoleColor = (role: string) => {
+  const getRoleBadgeClass = (role: string) => {
     switch (role) {
       case 'admin':
         return 'bg-purple-100 text-purple-800'
@@ -106,16 +107,18 @@ function ViewUser() {
               <CardTitle className="flex items-center justify-between">
                 {user.name}
                 <div className="flex gap-2">
-                  <span
-                    className={`px-2 py-1 rounded-full text-xs font-medium ${getRoleColor(user.role || 'buyer')}`}
+                  <Badge
+                    variant="secondary"
+                    className={`rounded-full ${getRoleBadgeClass(user.role || 'buyer')}`}
                   >
                     {user.role}
-                  </span>
-                  <span
-                    className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status || 'inactive')}`}
+                  </Badge>
+                  <Badge
+                    variant="secondary"
+                    className={`rounded-full ${getStatusBadgeClass(user.status || 'inactive')}`}
                   >
                     {user.status}
-                  </span>
+                  </Badge>
                 </div>
               </CardTitle>
             </CardHeader>
@@ -132,10 +135,22 @@ function ViewUser() {
                   <span className="font-semibold">Name:</span> {user.name}
                 </div>
                 <div>
-                  <span className="font-semibold">Role:</span> {user.role}
+                  <span className="font-semibold">Role:</span>
+                  <Badge
+                    variant="secondary"
+                    className={`ml-2 rounded-full ${getRoleBadgeClass(user.role || 'buyer')}`}
+                  >
+                    {user.role}
+                  </Badge>
                 </div>
                 <div>
-                  <span className="font-semibold">Status:</span> {user.status}
+                  <span className="font-semibold">Status:</span>
+                  <Badge
+                    variant="secondary"
+                    className={`ml-2 rounded-full ${getStatusBadgeClass(user.status || 'inactive')}`}
+                  >
+                    {user.status}
+                  </Badge>
                 </div>
                 {user.createdAt && (
                   <div>


### PR DESCRIPTION
## Summary
- show role and status badges on admin page consistently
- reuse same color scheme in admin user detail

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874f6436298832d9265aeea141a131a