### PR TITLE
Use badges for status across pages

### DIFF
--- a/client/pages/admin/ViewProduct.tsx
+++ b/client/pages/admin/ViewProduct.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import axios from '@/lib/axios'
 import type { Product } from '@/types/Product'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -97,11 +98,12 @@ function ViewProduct() {
             <CardHeader>
               <CardTitle className="flex items-center justify-between">
                 {product.name}
-                <span
-                  className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(product.status || 'inactive')}`}
+                <Badge
+                  variant="secondary"
+                  className={`rounded-full ${getStatusColor(product.status || 'inactive')}`}
                 >
                   {product.status}
-                </span>
+                </Badge>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/client/pages/admin/ViewSeller.tsx
+++ b/client/pages/admin/ViewSeller.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import axios from '@/lib/axios'
 import type { Seller } from '@/server/schema'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   AlertDialog,
@@ -94,11 +95,12 @@ function ViewSeller() {
             <CardHeader>
               <CardTitle className="flex items-center justify-between">
                 {seller.name}
-                <span
-                  className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(seller.status || 'inactive')}`}
+                <Badge
+                  variant="secondary"
+                  className={`rounded-full ${getStatusColor(seller.status || 'inactive')}`}
                 >
                   {seller.status}
-                </span>
+                </Badge>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/client/pages/buyer/OrderDetail.tsx
+++ b/client/pages/buyer/OrderDetail.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft, Package, Truck, CheckCircle, Clock } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { formatIDR } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
 
 // Interface matching the OpenAPI specification
 interface OrderDetail {
@@ -113,11 +114,12 @@ function OrderDetail() {
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
-                <span
-                  className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusColor(order.status)}`}
+                <Badge
+                  variant="secondary"
+                  className={`rounded-full ${getStatusColor(order.status || 'pending')}`}
                 >
                   {order.status}
-                </span>
+                </Badge>
                 <span className="text-sm text-gray-500">
                   {order.createdAt &&
                     new Date(order.createdAt).toLocaleDateString()}

--- a/client/pages/buyer/Orders.tsx
+++ b/client/pages/buyer/Orders.tsx
@@ -5,6 +5,7 @@ import { isAxiosError } from '@/lib/axios'
 import type { Order } from '@/server/schema'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Badge } from '@/components/ui/badge'
 import { Eye } from 'lucide-react'
 import { formatIDR } from '@/lib/utils'
 
@@ -31,6 +32,23 @@ function Orders() {
     fetchData()
   }, [])
 
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'processing':
+        return 'bg-blue-100 text-blue-800'
+      case 'shipped':
+        return 'bg-purple-100 text-purple-800'
+      case 'delivered':
+        return 'bg-green-100 text-green-800'
+      case 'cancelled':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
+    }
+  }
+
   if (loading) return <Skeleton className="h-20" />
   if (error) return <div className="text-red-600">{error}</div>
   if (!orders.length) return <div>No orders yet.</div>
@@ -49,21 +67,12 @@ function Orders() {
                   </div>
                   <div>
                     <span className="text-sm text-gray-600">Status: </span>
-                    <span
-                      className={`px-2 py-1 rounded-full text-xs font-medium ${
-                        o.status === 'pending'
-                          ? 'bg-yellow-100 text-yellow-800'
-                          : o.status === 'processing'
-                            ? 'bg-blue-100 text-blue-800'
-                            : o.status === 'shipped'
-                              ? 'bg-purple-100 text-purple-800'
-                              : o.status === 'delivered'
-                                ? 'bg-green-100 text-green-800'
-                                : 'bg-gray-100 text-gray-800'
-                      }`}
+                    <Badge
+                      variant="secondary"
+                      className={`rounded-full ${getStatusColor(o.status || 'pending')}`}
                     >
                       {o.status}
-                    </span>
+                    </Badge>
                   </div>
                 </div>
                 <div className="mt-2">

--- a/client/pages/seller/MyProducts.tsx
+++ b/client/pages/seller/MyProducts.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Spinner } from '@/components/ui/spinner'
 import { formatIDR } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
 
 function MyProducts() {
   const [products, setProducts] = useState<SellerProduct[]>([])
@@ -44,6 +45,21 @@ function MyProducts() {
     fetchData()
   }, [])
 
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'active':
+        return 'bg-green-100 text-green-800'
+      case 'inactive':
+        return 'bg-gray-100 text-gray-800'
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'flagged':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
+    }
+  }
+
   if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!products.length) return <div>No products yet.</div>
@@ -57,7 +73,15 @@ function MyProducts() {
           </CardHeader>
           <CardContent>
             <div>Price: {formatIDR(product.price)}</div>
-            <div>Status: {product.status}</div>
+            <div className="flex items-center gap-1">
+              <span>Status:</span>
+              <Badge
+                variant="secondary"
+                className={`rounded-full ${getStatusColor(product.status || 'inactive')}`}
+              >
+                {product.status}
+              </Badge>
+            </div>
             <Button onClick={() => handleDelete(product)} variant="destructive">
               Delete
             </Button>

--- a/client/pages/seller/OrdersReceived.tsx
+++ b/client/pages/seller/OrdersReceived.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Spinner } from '@/components/ui/spinner'
 import { formatIDR } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
 
 function OrdersReceived() {
   const [orders, setOrders] = useState<Order[]>([])
@@ -47,6 +48,23 @@ function OrdersReceived() {
     fetchData()
   }, [])
 
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'processing':
+        return 'bg-blue-100 text-blue-800'
+      case 'shipped':
+        return 'bg-purple-100 text-purple-800'
+      case 'delivered':
+        return 'bg-green-100 text-green-800'
+      case 'cancelled':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
+    }
+  }
+
   if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
   if (!orders.length) return <div>No orders yet.</div>
@@ -61,7 +79,15 @@ function OrdersReceived() {
           <CardContent>
             <div>Quantity: {order.quantity}</div>
             <div>Total: {formatIDR(order.total)}</div>
-            <div>Status: {order.status}</div>
+            <div className="flex items-center gap-1">
+              <span>Status:</span>
+              <Badge
+                variant="secondary"
+                className={`rounded-full ${getStatusColor(order.status || 'pending')}`}
+              >
+                {order.status}
+              </Badge>
+            </div>
             <div className="flex gap-2 mt-2">
               <Button onClick={() => handleUpdateStatus(order, 'ship')}>
                 Mark as Shipped

--- a/client/pages/seller/Payouts.tsx
+++ b/client/pages/seller/Payouts.tsx
@@ -9,6 +9,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Plus, DollarSign, X } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { formatIDR } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
 
 function Payouts() {
   const [payouts, setPayouts] = useState<SellerPayout[]>([])
@@ -165,11 +166,12 @@ function Payouts() {
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
                   Payout #{payout.id}
-                  <span
-                    className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(payout.status || 'pending')}`}
+                  <Badge
+                    variant="secondary"
+                    className={`rounded-full ${getStatusColor(payout.status || 'pending')}`}
                   >
                     {payout.status}
-                  </span>
+                  </Badge>
                 </CardTitle>
               </CardHeader>
               <CardContent>

--- a/client/pages/seller/ViewProduct.tsx
+++ b/client/pages/seller/ViewProduct.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ArrowLeft } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { formatIDR } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
 
 function ViewProduct() {
   const { id } = useParams<{ id: string }>()
@@ -33,6 +34,21 @@ function ViewProduct() {
   useEffect(() => {
     fetchProduct()
   }, [fetchProduct])
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'active':
+        return 'bg-green-100 text-green-800'
+      case 'inactive':
+        return 'bg-gray-100 text-gray-800'
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800'
+      case 'flagged':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
+    }
+  }
 
   if (loading) return <Spinner />
   if (error) return <div className="text-red-600">{error}</div>
@@ -75,7 +91,12 @@ function ViewProduct() {
               <h3 className="font-semibold text-sm text-muted-foreground">
                 Status
               </h3>
-              <p className="text-sm">{product.status}</p>
+              <Badge
+                variant="secondary"
+                className={`rounded-full ${getStatusColor(product.status || 'inactive')}`}
+              >
+                {product.status}
+              </Badge>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- replace spans with `<Badge>` for seller detail page
- show product status with badge on admin view page
- display status as badge on buyer order list and detail pages
- convert payout, seller product, and order pages to badge style

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874f8d3f574832d9c83f53f5e1cc228