### PR TITLE
Move product management from dashboard

### DIFF
--- a/client/pages/seller/AddProduct.tsx
+++ b/client/pages/seller/AddProduct.tsx
@@ -19,23 +19,24 @@ function AddProduct() {
     e.preventDefault()
     setLoading(true)
     setError(null)
-    
+
     const formData = new FormData(e.currentTarget)
     const productData = {
       name: formData.get('name') as string,
       price: Number(formData.get('price')),
       description: formData.get('description') as string,
-      imageUrl: formData.get('imageUrl') as string || undefined,
+      imageUrl: (formData.get('imageUrl') as string) || undefined,
     }
 
     try {
       await axios.post('/api/seller/products', productData)
       // Trigger refresh of product list
       refreshProducts()
-      navigate('/seller/dashboard')
+      navigate('/seller/products')
     } catch (err: unknown) {
       console.error('Failed to create product:', err)
-      const errorMessage = err instanceof Error ? err.message : 'Failed to create product'
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to create product'
       setError(errorMessage)
     } finally {
       setLoading(false)
@@ -55,7 +56,14 @@ function AddProduct() {
           </div>
           <div>
             <Label htmlFor="price">Price</Label>
-            <Input id="price" name="price" type="number" step="0.01" min="0" required />
+            <Input
+              id="price"
+              name="price"
+              type="number"
+              step="0.01"
+              min="0"
+              required
+            />
           </div>
           <div>
             <Label htmlFor="description">Description</Label>
@@ -70,10 +78,10 @@ function AddProduct() {
             <Button type="submit" disabled={loading}>
               {loading ? 'Creating...' : 'Create Product'}
             </Button>
-            <Button 
-              type="button" 
-              variant="outline" 
-              onClick={() => navigate('/seller/dashboard')}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => navigate('/seller/products')}
             >
               Cancel
             </Button>

--- a/client/pages/seller/EditProduct.tsx
+++ b/client/pages/seller/EditProduct.tsx
@@ -53,7 +53,7 @@ function EditProduct() {
       await axios.put(`/api/seller/products/${id}`, productData)
       // Trigger refresh of product list
       refreshProducts()
-      navigate('/seller/dashboard')
+      navigate('/seller/products')
     } catch (err: unknown) {
       console.error('Failed to update product:', err)
       const errorMessage =
@@ -121,7 +121,7 @@ function EditProduct() {
             <Button
               type="button"
               variant="outline"
-              onClick={() => navigate('/seller/dashboard')}
+              onClick={() => navigate('/seller/products')}
             >
               Cancel
             </Button>

--- a/client/pages/seller/SellerDashboard.tsx
+++ b/client/pages/seller/SellerDashboard.tsx
@@ -6,7 +6,6 @@ import type { SellerProduct, Order } from '@/types/Seller'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
-import { formatIDR } from '@/lib/utils'
 import { sellerProductsRefreshAtom } from '@/atoms/sellerAtoms'
 
 function SellerDashboard() {
@@ -36,23 +35,8 @@ function SellerDashboard() {
     }
   }
 
-  const handleCreateProduct = () => {
-    navigate('/seller/add-product')
-  }
-
-  const handleDeleteProduct = async (productId: number) => {
-    if (!confirm('Are you sure you want to delete this product?')) {
-      return
-    }
-
-    try {
-      await axios.delete(`/api/seller/products/${productId}`)
-      // Refresh the product list
-      await fetchData()
-    } catch (err) {
-      console.error('Failed to delete product:', err)
-      setError('Failed to delete product')
-    }
+  const handleManageProducts = () => {
+    navigate('/seller/products')
   }
 
   useEffect(() => {
@@ -87,68 +71,9 @@ function SellerDashboard() {
         </Card>
       </div>
 
-      {/* Products List */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>My Products</CardTitle>
-          <Button onClick={handleCreateProduct}>Create Product</Button>
-        </CardHeader>
-        <CardContent>
-          {products.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              No products yet. Create your first product!
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {products.map((product) => (
-                <div
-                  key={product.id}
-                  className="flex items-center justify-between p-4 border rounded-lg"
-                >
-                  <div>
-                    <h3 className="font-semibold">{product.name}</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {formatIDR(product.price)}
-                    </p>
-                    {product.description && (
-                      <p className="text-sm text-muted-foreground mt-1">
-                        {product.description}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        navigate(`/seller/view-product/${product.id}`)
-                      }
-                    >
-                      View
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        navigate(`/seller/edit-product/${product.id}`)
-                      }
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => handleDeleteProduct(product.id)}
-                    >
-                      Delete
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <div className="flex justify-end">
+        <Button onClick={handleManageProducts}>Manage Products</Button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove product list from seller dashboard
- move product management UI to `/seller/products`
- redirect add/edit product pages back to the products list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68751b93eeec832db37a966628c04e09