### PR TITLE
Refactor seller orders and payouts pages

### DIFF
--- a/client/pages/seller/Payouts.tsx
+++ b/client/pages/seller/Payouts.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useState } from 'react'
 import axios from '@/lib/axios'
 import type { SellerPayout } from '@/types/Seller'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { DataTable } from '@/components/DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { Plus, DollarSign, X } from 'lucide-react'
-import { Spinner } from '@/components/ui/spinner'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Plus } from 'lucide-react'
 import { formatIDR } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 
@@ -15,7 +24,7 @@ function Payouts() {
   const [payouts, setPayouts] = useState<SellerPayout[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [isRequestModalOpen, setIsRequestModalOpen] = useState(false)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [requestLoading, setRequestLoading] = useState(false)
   const [requestError, setRequestError] = useState<string | null>(null)
 
@@ -50,7 +59,7 @@ function Payouts() {
 
       // Refresh the payouts list
       await fetchData()
-      setIsRequestModalOpen(false)
+      setIsDialogOpen(false)
 
       // Reset form
       e.currentTarget.reset()
@@ -79,131 +88,106 @@ function Payouts() {
     }
   }
 
-  if (loading) return <Spinner />
+  const columns: ColumnDef<SellerPayout>[] = [
+    {
+      accessorKey: 'id',
+      header: 'ID',
+      meta: { widthClass: 'w-16' },
+    },
+    {
+      accessorKey: 'amount',
+      header: 'Amount',
+      cell: ({ row }) => formatIDR(row.original.amount ?? 0),
+      meta: { widthClass: 'w-28', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'date',
+      header: 'Date',
+      cell: ({ row }) =>
+        row.original.date
+          ? new Date(row.original.date).toLocaleDateString()
+          : 'N/A',
+      meta: { widthClass: 'w-28', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => (
+        <Badge
+          variant="secondary"
+          className={`rounded-full ${getStatusColor(row.original.status || 'pending')}`}
+        >
+          {row.original.status}
+        </Badge>
+      ),
+      meta: { widthClass: 'w-28', cellClass: 'truncate' },
+    },
+  ]
+
   if (error) return <div className="text-red-600">{error}</div>
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold">Payouts</h2>
-        <Button onClick={() => setIsRequestModalOpen(true)}>
-          <Plus className="h-4 w-4 mr-2" />
-          Request Payout
-        </Button>
+        <DialogTrigger asChild>
+          <Button>
+            <Plus className="h-4 w-4 mr-2" />
+            Request Payout
+          </Button>
+        </DialogTrigger>
       </div>
 
-      {/* Request Payout Modal */}
-      {isRequestModalOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-md">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Request New Payout</h3>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsRequestModalOpen(false)}
-              >
-                <X className="h-4 w-4" />
-              </Button>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Request New Payout</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleRequestPayout} className="space-y-4">
+            <div>
+              <Label htmlFor="amount">Amount ($)</Label>
+              <Input
+                id="amount"
+                name="amount"
+                type="number"
+                step="0.01"
+                min="0"
+                required
+                placeholder="Enter amount"
+              />
             </div>
-            <form onSubmit={handleRequestPayout} className="space-y-4">
-              <div>
-                <Label htmlFor="amount">Amount ($)</Label>
-                <Input
-                  id="amount"
-                  name="amount"
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  required
-                  placeholder="Enter amount"
-                />
-              </div>
-              <div>
-                <Label htmlFor="bankAccount">Bank Account Details</Label>
-                <Textarea
-                  id="bankAccount"
-                  name="bankAccount"
-                  required
-                  placeholder="Enter your bank account information"
-                  rows={3}
-                />
-              </div>
-              {requestError && (
-                <div className="text-red-600 text-sm">{requestError}</div>
-              )}
-              <div className="flex gap-2">
-                <Button
-                  type="submit"
-                  disabled={requestLoading}
-                  className="flex-1"
-                >
-                  {requestLoading ? 'Requesting...' : 'Request Payout'}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setIsRequestModalOpen(false)}
-                >
+            <div>
+              <Label htmlFor="bankAccount">Bank Account Details</Label>
+              <Textarea
+                id="bankAccount"
+                name="bankAccount"
+                required
+                placeholder="Enter your bank account information"
+                rows={3}
+              />
+            </div>
+            {requestError && (
+              <div className="text-red-600 text-sm">{requestError}</div>
+            )}
+            <DialogFooter>
+              <Button
+                type="submit"
+                disabled={requestLoading}
+                className="flex-1"
+              >
+                {requestLoading ? 'Requesting...' : 'Request Payout'}
+              </Button>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
                   Cancel
                 </Button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
+              </DialogClose>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
 
-      {!payouts.length ? (
-        <div className="text-center py-8 text-gray-500">
-          <DollarSign className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-          <p>No payouts yet.</p>
-          <p className="text-sm">Request your first payout to get started.</p>
-        </div>
-      ) : (
-        <div className="grid gap-4">
-          {payouts.map((payout) => (
-            <Card key={payout.id}>
-              <CardHeader>
-                <CardTitle className="flex items-center justify-between">
-                  Payout #{payout.id}
-                  <Badge
-                    variant="secondary"
-                    className={`rounded-full ${getStatusColor(payout.status || 'pending')}`}
-                  >
-                    {payout.status}
-                  </Badge>
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <span className="font-semibold">Amount:</span>
-                    <p className="text-lg font-bold text-green-600">
-                      {formatIDR(payout.amount ?? 0)}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="font-semibold">Date:</span>
-                    <p className="text-sm text-gray-600">
-                      {payout.date
-                        ? new Date(payout.date).toLocaleDateString()
-                        : 'N/A'}
-                    </p>
-                  </div>
-                  {payout.createdAt && (
-                    <div className="col-span-2">
-                      <span className="font-semibold">Created:</span>
-                      <p className="text-sm text-gray-600">
-                        {new Date(payout.createdAt).toLocaleString()}
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
+      <DataTable columns={columns} data={payouts} isLoading={loading} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- refactor Seller OrdersReceived to use DataTable and alert dialogs
- refactor Seller Payouts to use DataTable and dialog modal
- align seller UI with admin style

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68751c0fccac832da477774cb9beb207