### PR TITLE
Right align DataTable actions column

### DIFF
--- a/client/components/DataTable.tsx
+++ b/client/components/DataTable.tsx
@@ -144,10 +144,16 @@ export function DataTable<TData, TValue>({
                       }
                       className={cn(
                         canSort ? 'cursor-pointer select-none' : '',
-                        meta?.widthClass
+                        meta?.widthClass,
+                        header.column.id === 'actions' ? 'text-right' : ''
                       )}
                     >
-                      <div className="flex items-center gap-1">
+                      <div
+                        className={cn(
+                          'flex items-center gap-1',
+                          header.column.id === 'actions' ? 'justify-end' : ''
+                        )}
+                      >
                         {flexRender(
                           header.column.columnDef.header,
                           header.getContext()

--- a/client/pages/admin/ManageProducts.tsx
+++ b/client/pages/admin/ManageProducts.tsx
@@ -65,7 +65,7 @@ function ManageProducts() {
       cell: ({ row }) => {
         const p = row.original
         return (
-          <div className="flex gap-1">
+          <div className="flex gap-1 justify-end">
             <Button
               size="sm"
               variant="outline"

--- a/client/pages/admin/ManageSellers.tsx
+++ b/client/pages/admin/ManageSellers.tsx
@@ -58,7 +58,7 @@ function ManageSellers() {
       cell: ({ row }) => {
         const s = row.original
         return (
-          <div className="flex gap-1">
+          <div className="flex gap-1 justify-end">
             <Button
               size="sm"
               variant="outline"

--- a/client/pages/admin/ManageUsers.tsx
+++ b/client/pages/admin/ManageUsers.tsx
@@ -107,7 +107,7 @@ function ManageUsers() {
       cell: ({ row }) => {
         const u = row.original
         return (
-          <div className="flex gap-1">
+          <div className="flex gap-1 justify-end">
             <Button
               size="sm"
               variant="outline"


### PR DESCRIPTION
## Summary
- right align the Actions column header in `DataTable`
- justify action buttons to the end in admin tables

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68751d04a344832da6927d65a9cccbd6