### PR TITLE
Align server schema with OpenAPI

### DIFF
--- a/client/pages/seller/Payouts.tsx
+++ b/client/pages/seller/Payouts.tsx
@@ -101,12 +101,14 @@ function Payouts() {
       meta: { widthClass: 'w-28', cellClass: 'truncate' },
     },
     {
-      accessorKey: 'date',
+      accessorKey: 'processedAt',
       header: 'Date',
       cell: ({ row }) =>
-        row.original.date
-          ? new Date(row.original.date).toLocaleDateString()
-          : 'N/A',
+        row.original.processedAt
+          ? new Date(row.original.processedAt).toLocaleDateString()
+          : row.original.createdAt
+            ? new Date(row.original.createdAt).toLocaleDateString()
+            : 'N/A',
       meta: { widthClass: 'w-28', cellClass: 'truncate' },
     },
     {

--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -940,7 +940,8 @@ export async function createSellerPayout(token: string, payoutData: {
 
   const payout = await db.insert(sellerPayouts).values({
     amount: payoutData.amount,
-    date: new Date().toISOString(),
+    bankAccount: payoutData.bankAccount,
+    processedAt: null,
     sellerId: sellerProfile[0].id,
     status: 'pending'
   }).returning().get();
@@ -975,9 +976,10 @@ export async function updateSellerOrderStatus(token: string, orderId: number, st
   }
 
   // Update order status
-  await db.update(orders).set({ 
-    status: statusData.status, 
-    updatedAt: new Date().toISOString() 
+  await db.update(orders).set({
+    status: statusData.status,
+    trackingNumber: statusData.trackingNumber,
+    updatedAt: new Date().toISOString()
   }).where(eq(orders.id, orderId)).run();
 
   // Return updated order
@@ -1018,8 +1020,11 @@ export async function createBuyerOrder(token: string, orderData: {
       productId: item.productId,
       productName: productData.name,
       quantity: item.quantity,
+      items: JSON.stringify([{ productId: item.productId, quantity: item.quantity }]),
       total: itemTotal,
       status: 'pending',
+      shippingAddress: orderData.shippingAddress,
+      paymentMethod: orderData.paymentMethod,
       buyerId: buyer.id,
       sellerId: productData.sellerId
     }).returning().get();

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -40,6 +40,8 @@ export const sellers = sqliteTable('sellers', {
   logo: text('logo'),
   bio: text('bio'),
   contact: text('contact'),
+  address: text('address'),
+  website: text('website'),
   status: text('status'), // 'active' | 'inactive' | 'pending'
   createdAt: text('createdAt').default(sql`CURRENT_TIMESTAMP`),
   updatedAt: text('updatedAt').default(sql`CURRENT_TIMESTAMP`),
@@ -68,8 +70,12 @@ export const orders = sqliteTable('orders', {
   productId: integer('productId').notNull(),
   productName: text('productName').notNull(),
   quantity: integer('quantity').notNull(),
+  items: text('items'), // JSON string of cart items
   total: real('total').notNull(),
   status: text('status'), // 'pending' | 'processing' | 'shipped' | 'delivered'
+  shippingAddress: text('shippingAddress'),
+  paymentMethod: text('paymentMethod'),
+  trackingNumber: text('trackingNumber'),
   buyerId: integer('buyerId'), // ID of the buyer who placed the order
   sellerId: integer('sellerId'), // ID of the seller who owns the product
   createdAt: text('createdAt').default(sql`CURRENT_TIMESTAMP`),
@@ -82,7 +88,8 @@ export const orders = sqliteTable('orders', {
 export const sellerPayouts = sqliteTable('sellerPayouts', {
   id: integer('id').primaryKey(),
   amount: real('amount').notNull(),
-  date: text('date').notNull(),
+  bankAccount: text('bankAccount'),
+  processedAt: text('processedAt'),
   sellerId: integer('sellerId'),
   status: text('status'), // 'pending' | 'completed' | 'failed'
   createdAt: text('createdAt').default(sql`CURRENT_TIMESTAMP`),
@@ -186,6 +193,8 @@ export const createTableStatements = [
     logo TEXT,
     bio TEXT,
     contact TEXT,
+    address TEXT,
+    website TEXT,
     status TEXT,
     createdAt TEXT,
     updatedAt TEXT
@@ -210,8 +219,12 @@ export const createTableStatements = [
     productId INTEGER NOT NULL,
     productName TEXT NOT NULL,
     quantity INTEGER NOT NULL,
+    items TEXT,
     total REAL NOT NULL,
     status TEXT,
+    shippingAddress TEXT,
+    paymentMethod TEXT,
+    trackingNumber TEXT,
     buyerId INTEGER,
     sellerId INTEGER,
     createdAt TEXT,
@@ -222,7 +235,8 @@ export const createTableStatements = [
   CREATE TABLE IF NOT EXISTS sellerPayouts (
     id INTEGER PRIMARY KEY,
     amount REAL NOT NULL,
-    date TEXT NOT NULL,
+    bankAccount TEXT,
+    processedAt TEXT,
     sellerId INTEGER,
     status TEXT,
     createdAt TEXT,

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -129,17 +129,17 @@ const seedSettings = [
 
 const seedOrders = [
   // Sari's orders (buyerId: 2)
-  { id: 1, productId: 1, productName: 'Headphone Wireless Sony WH-1000XM4', quantity: 2, total: 5000000, status: 'pending', buyerId: 2, sellerId: 1, createdAt: '2024-01-15T10:30:00Z', updatedAt: '2024-01-15T10:30:00Z' },
-  { id: 2, productId: 4, productName: 'Alpukat Mentega Segar', quantity: 5, total: 125000, status: 'shipped', buyerId: 2, sellerId: 2, createdAt: '2024-01-14T09:15:00Z', updatedAt: '2024-01-14T09:15:00Z' },
-  { id: 3, productId: 7, productName: 'Laptop Stand Aluminium Premium', quantity: 1, total: 350000, status: 'delivered', buyerId: 2, sellerId: 3, createdAt: '2024-01-13T14:20:00Z', updatedAt: '2024-01-13T14:20:00Z' },
+  { id: 1, productId: 1, productName: 'Headphone Wireless Sony WH-1000XM4', quantity: 2, items: '[{"productId":1,"quantity":2}]', total: 5000000, status: 'pending', shippingAddress: '123 Main St', paymentMethod: 'credit_card', buyerId: 2, sellerId: 1, createdAt: '2024-01-15T10:30:00Z', updatedAt: '2024-01-15T10:30:00Z' },
+  { id: 2, productId: 4, productName: 'Alpukat Mentega Segar', quantity: 5, items: '[{"productId":4,"quantity":5}]', total: 125000, status: 'shipped', shippingAddress: '123 Main St', paymentMethod: 'credit_card', trackingNumber: 'TRK1002', buyerId: 2, sellerId: 2, createdAt: '2024-01-14T09:15:00Z', updatedAt: '2024-01-14T09:15:00Z' },
+  { id: 3, productId: 7, productName: 'Laptop Stand Aluminium Premium', quantity: 1, items: '[{"productId":7,"quantity":1}]', total: 350000, status: 'delivered', shippingAddress: '123 Main St', paymentMethod: 'credit_card', trackingNumber: 'TRK1003', buyerId: 2, sellerId: 3, createdAt: '2024-01-13T14:20:00Z', updatedAt: '2024-01-13T14:20:00Z' },
   
   // Fitri's orders (buyerId: 6)
-  { id: 4, productId: 10, productName: 'Tas Kulit Asli Batik', quantity: 1, total: 1800000, status: 'pending', buyerId: 6, sellerId: 4, createdAt: '2024-01-16T11:45:00Z', updatedAt: '2024-01-16T11:45:00Z' },
-  { id: 5, productId: 8, productName: 'Keyboard Mechanical RGB Logitech', quantity: 1, total: 1200000, status: 'processing', buyerId: 6, sellerId: 3, createdAt: '2024-01-15T16:30:00Z', updatedAt: '2024-01-15T16:30:00Z' },
+  { id: 4, productId: 10, productName: 'Tas Kulit Asli Batik', quantity: 1, items: '[{"productId":10,"quantity":1}]', total: 1800000, status: 'pending', shippingAddress: '123 Main St', paymentMethod: 'credit_card', buyerId: 6, sellerId: 4, createdAt: '2024-01-16T11:45:00Z', updatedAt: '2024-01-16T11:45:00Z' },
+  { id: 5, productId: 8, productName: 'Keyboard Mechanical RGB Logitech', quantity: 1, items: '[{"productId":8,"quantity":1}]', total: 1200000, status: 'processing', shippingAddress: '123 Main St', paymentMethod: 'credit_card', buyerId: 6, sellerId: 3, createdAt: '2024-01-15T16:30:00Z', updatedAt: '2024-01-15T16:30:00Z' },
   
   // Fitri's additional orders (buyerId: 6)
-  { id: 6, productId: 3, productName: 'Smartwatch Samsung Galaxy Watch 5', quantity: 1, total: 3500000, status: 'shipped', buyerId: 6, sellerId: 1, createdAt: '2024-01-14T13:10:00Z', updatedAt: '2024-01-14T13:10:00Z' },
-  { id: 7, productId: 5, productName: 'Stroberi Segar Lembang', quantity: 3, total: 135000, status: 'delivered', buyerId: 6, sellerId: 2, createdAt: '2024-01-13T10:25:00Z', updatedAt: '2024-01-13T10:25:00Z' },
+  { id: 6, productId: 3, productName: 'Smartwatch Samsung Galaxy Watch 5', quantity: 1, items: '[{"productId":3,"quantity":1}]', total: 3500000, status: 'shipped', shippingAddress: '123 Main St', paymentMethod: 'credit_card', trackingNumber: 'TRK1006', buyerId: 6, sellerId: 1, createdAt: '2024-01-14T13:10:00Z', updatedAt: '2024-01-14T13:10:00Z' },
+  { id: 7, productId: 5, productName: 'Stroberi Segar Lembang', quantity: 3, items: '[{"productId":5,"quantity":3}]', total: 135000, status: 'delivered', shippingAddress: '123 Main St', paymentMethod: 'credit_card', trackingNumber: 'TRK1007', buyerId: 6, sellerId: 2, createdAt: '2024-01-13T10:25:00Z', updatedAt: '2024-01-13T10:25:00Z' },
 ];
 
 const seedCartItems = [
@@ -155,19 +155,19 @@ const seedCartItems = [
 
 const seedSellerPayouts = [
   // Toko Elektronik Maju payouts (sellerId: 1)
-  { id: 1, amount: 8500000, date: '2024-01-15', sellerId: 1, status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
-  { id: 2, amount: 12500000, date: '2024-01-10', sellerId: 1, status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 1, amount: 8500000, bankAccount: '1234567890', sellerId: 1, status: 'completed', processedAt: '2024-01-15T00:00:00Z', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 2, amount: 12500000, bankAccount: '1234567890', sellerId: 1, status: 'completed', processedAt: '2024-01-10T00:00:00Z', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
   
   // Warung Buah Segar payouts (sellerId: 2)
-  { id: 3, amount: 5000000, date: '2024-01-15', sellerId: 2, status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
-  { id: 4, amount: 7500000, date: '2024-01-08', sellerId: 2, status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 3, amount: 5000000, bankAccount: '1234567890', sellerId: 2, status: 'completed', processedAt: '2024-01-15T00:00:00Z', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 4, amount: 7500000, bankAccount: '1234567890', sellerId: 2, status: 'completed', processedAt: '2024-01-08T00:00:00Z', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
   
   // Toko Gadget Indonesia payouts (sellerId: 3)
-  { id: 5, amount: 10000000, date: '2024-01-15', sellerId: 3, status: 'pending', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
-  { id: 6, amount: 6500000, date: '2024-01-12', sellerId: 3, status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 5, amount: 10000000, bankAccount: '1234567890', sellerId: 3, status: 'pending', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 6, amount: 6500000, bankAccount: '1234567890', sellerId: 3, status: 'completed', processedAt: '2024-01-12T00:00:00Z', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
   
   // Boutique Fashion Nusantara payouts (sellerId: 4)
-  { id: 7, amount: 13500000, date: '2024-01-15', sellerId: 4, status: 'pending', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+  { id: 7, amount: 13500000, bankAccount: '1234567890', sellerId: 4, status: 'pending', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
 ];
 
 // --- Seed function ---


### PR DESCRIPTION
## Summary
- extend DB tables with fields defined by `openapi.yaml`
- update seeding data for new fields
- adjust controllers to persist new data
- tweak seller payout table columns
- show processed payout date on seller payouts page

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687524b6ed58832d92078842471daf93