### PR TITLE
Allow guest access to buyer pages

### DIFF
--- a/client/pages/Loading.tsx
+++ b/client/pages/Loading.tsx
@@ -4,6 +4,8 @@ import { useAtom } from 'jotai'
 import { tokenAtom, userAtom } from '../atoms/loginAtoms'
 import Footer from '../components/Footer'
 
+// Redirect users based on authentication. Guests are sent to the public home
+// page while authenticated users land on their respective dashboards.
 function Loading() {
   const navigate = useNavigate()
   const [token] = useAtom(tokenAtom)
@@ -13,24 +15,19 @@ function Loading() {
     console.log('Loading component - token:', token, 'user:', user)
     console.log('Current location:', window.location.href)
 
-    // Check if we have token and user from atoms
+    // If authenticated, route to the proper dashboard
     if (token && user) {
       console.log('User authenticated, navigating to:', user.role)
       if (user.role === 'buyer') {
-        console.log('Navigating to /home')
         navigate('/home', { replace: true })
       } else if (user.role === 'seller') {
-        console.log('Navigating to /seller')
         navigate('/seller', { replace: true })
       } else if (user.role === 'admin') {
-        console.log('Navigating to /admin')
         navigate('/admin', { replace: true })
       }
     } else {
-      console.log('No authentication, redirecting to login')
-      console.log('Navigating to /login')
-      // No authentication, redirect to login
-      navigate('/login', { replace: true })
+      // Guests should land on the public home page
+      navigate('/home', { replace: true })
     }
   }, [navigate, token, user])
 

--- a/client/pages/buyer/Home.tsx
+++ b/client/pages/buyer/Home.tsx
@@ -4,9 +4,11 @@ import SectionTitle from '@/components/SectionTitle'
 
 function BuyerHome() {
   const [user] = useAtom(userAtom)
+  const greeting = user ? `Welcome, ${user.name}` : 'Welcome to MarketPlace'
+
   return (
     <div className="space-y-4">
-      <SectionTitle>Welcome, {user?.name}</SectionTitle>
+      <SectionTitle>{greeting}</SectionTitle>
       <p className="text-muted-foreground">
         Browse our latest products and promotions.
       </p>


### PR DESCRIPTION
## Summary
- redirect guests from the root loader to `/home`
- show a friendly greeting on the home page when not logged in
- document guest redirect logic

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68752d458f08832d850e4d5f85d3504c