### PR TITLE
Add base URL support to axios client

### DIFF
--- a/client/lib/axios.ts
+++ b/client/lib/axios.ts
@@ -2,18 +2,21 @@ import axios from 'axios'
 import { getDefaultStore } from 'jotai'
 import { tokenAtom, userAtom } from '@/atoms/loginAtoms'
 
-const instance = axios.create()
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+const instance = axios.create({
+  baseURL: API_BASE_URL,
+})
 
 // Request interceptor to add authorization header
 instance.interceptors.request.use(
   (config) => {
     const store = getDefaultStore()
     const token = store.get(tokenAtom)
-    
+
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
-    
+
     return config
   },
   (error) => {


### PR DESCRIPTION
## Summary
- add a configurable `API_BASE_URL` to the axios instance

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6875b424eaac832d91d777f031e5b633