### PR TITLE
Add wallet balance API endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -332,6 +332,81 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/wallet/balance:
+    get:
+      operationId: getWalletBalance
+      summary: Get wallet balance
+      description: Retrieve only the stablecoin balance for the authenticated user.
+      tags:
+      - Wallet
+      security:
+      - BearerAuth: []
+      responses:
+        '200':
+          description: Wallet balance retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WalletBalance'
+        '401':
+          description: Unauthorized - invalid or missing authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/wallet/{userId}:
+    get:
+      operationId: getWalletByUserId
+      summary: Get user wallet
+      description: Retrieve wallet information for a specific user (admin only).
+      tags:
+      - Admin
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: User ID
+      responses:
+        '200':
+          description: Wallet retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Wallet'
+        '401':
+          description: Unauthorized - invalid or missing authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/settings:
     get:
       operationId: getApplicationSettings
@@ -2939,6 +3014,15 @@ components:
           format: date-time
           description: Wallet last update timestamp
           example: '2024-01-01T00:00:00Z'
+    WalletBalance:
+      type: object
+      required:
+      - balance
+      properties:
+        balance:
+          type: string
+          description: Current stablecoin balance
+          example: "0"
     DashboardStats:
       type: object
       required:

--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -1092,4 +1092,65 @@ export async function createBuyerOrder(token: string, orderData: {
   return createdOrders[0] || null;
 }
 
+// === WALLET CONTROLLERS ===
+
+/**
+ * Get wallet for current user
+ */
+export async function getUserWallet(token: string): Promise<Wallet | null> {
+  const user = await validateToken(token);
+  if (!user) {
+    return null;
+  }
+
+  const db = await drizzleDb();
+  const walletRows = await db
+    .select()
+    .from(wallets)
+    .where(eq(wallets.userId, user.id))
+    .all();
+
+  return walletRows[0] || null;
+}
+
+/**
+ * Get wallet balance for current user
+ */
+export async function getWalletBalance(token: string): Promise<string | null> {
+  const wallet = await getUserWallet(token);
+  return wallet ? wallet.balance : null;
+}
+
+/**
+ * Admin: get wallet for any user
+ */
+export async function getWalletByUserId(token: string, userId: number): Promise<Wallet | null> {
+  const admin = await checkAdminAccess(token);
+  if (!admin) {
+    return null;
+  }
+
+  const db = await drizzleDb();
+  const walletRows = await db
+    .select()
+    .from(wallets)
+    .where(eq(wallets.userId, userId))
+    .all();
+
+  return walletRows[0] || null;
+}
+
+/**
+ * Admin: get all wallets
+ */
+export async function getAllWallets(token: string): Promise<Wallet[] | null> {
+  const admin = await checkAdminAccess(token);
+  if (!admin) {
+    return null;
+  }
+
+  const db = await drizzleDb();
+  return await db.select().from(wallets).all();
+}
+
 // === EXISTING CONTROLLERS ===

--- a/spec.md
+++ b/spec.md
@@ -121,6 +121,7 @@ _All endpoints are described in `openapi.yaml` and must conform to that file._
 |GET|`/api/me`|Bearer token|`PublicUser`|
 |PUT|`/api/me`|`{name?:string; username?:string;}`|`PublicUser`|
 |GET|`/api/wallet`|Bearer token|`Wallet`|
+|GET|`/api/wallet/balance`|Bearer token|`WalletBalance`|
 
 ### Settings
 | GET | `/api/settings` | - | `Setting[]` |
@@ -139,6 +140,7 @@ _All endpoints are described in `openapi.yaml` and must conform to that file._
 |GET|`/api/admin/products/{id}`|Bearer|`Product`|
 |PATCH|`/api/admin/products/{id}`|`{action:'approve'|'reject'|'flag'|'remove'}`|`Product` or 200 empty on remove|
 |GET|`/api/admin/wallets`|Bearer|`Wallet[]`|
+|GET|`/api/wallet/{userId}`|Bearer|`Wallet`|
 |GET|`/api/admin/reports`|Bearer|`Report[]`|
 |PATCH|`/api/admin/reports/{id}`|`{action:'resolve'}`|`Report`|
 |GET|`/api/admin/settings`|Bearer|`Record<string,string>`|


### PR DESCRIPTION
## Summary
- implement wallet controller helpers
- expose `/api/wallet`, `/api/wallet/balance`, `/api/wallet/{userId}`, and `/api/admin/wallets` endpoints
- document new wallet endpoints in OpenAPI spec and spec.md

## Testing
- `npm run lint`
- `npm run lint:openapi`


------
https://chatgpt.com/codex/tasks/task_b_687a44c97fe4832da738f30bf48fc44e