### PR TITLE
Add wallet state and balance handling

### DIFF
--- a/client/atoms/loginAtoms.ts
+++ b/client/atoms/loginAtoms.ts
@@ -1,6 +1,7 @@
 // loginAtoms.ts
 import type { User } from '@/server/schema';
 import { atom } from 'jotai';
+import { clearWalletAtom } from './walletAtoms';
 
 // Helper functions for localStorage
 const getStoredToken = (): string | null => {
@@ -64,6 +65,7 @@ export const logoutAtom = atom(
     console.log('Logout atom called');
     set(tokenAtom, null);
     set(userAtom, null);
+    set(clearWalletAtom);
     setStoredToken(null);
     setStoredUser(null);
   }

--- a/client/atoms/walletAtoms.ts
+++ b/client/atoms/walletAtoms.ts
@@ -1,0 +1,45 @@
+import { atom } from 'jotai'
+import type { Wallet } from '@/server/schema'
+import axios from '@/lib/axios'
+
+const WALLET_KEY = 'wallet_info'
+
+const getStoredWallet = (): Wallet | null => {
+  try {
+    const data = localStorage.getItem(WALLET_KEY)
+    return data ? (JSON.parse(data) as Wallet) : null
+  } catch {
+    return null
+  }
+}
+
+const setStoredWallet = (wallet: Wallet | null) => {
+  try {
+    if (wallet) {
+      localStorage.setItem(WALLET_KEY, JSON.stringify(wallet))
+    } else {
+      localStorage.removeItem(WALLET_KEY)
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export const walletAtom = atom<Wallet | null>(getStoredWallet())
+
+export const balanceAtom = atom((get) => get(walletAtom)?.balance || '0')
+
+export const loadWalletAtom = atom(null, async (_get, set) => {
+  try {
+    const res = await axios.get<Wallet>('/api/wallet')
+    set(walletAtom, res.data)
+    setStoredWallet(res.data)
+  } catch {
+    // ignore errors for now
+  }
+})
+
+export const clearWalletAtom = atom(null, async (_get, set) => {
+  set(walletAtom, null)
+  setStoredWallet(null)
+})

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -7,8 +7,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
 import { Alert, AlertDescription } from '../components/ui/alert'
 import { Badge } from '../components/ui/badge'
 import axios from '@/lib/axios'
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { tokenAtom, userAtom } from '../atoms/loginAtoms'
+import { loadWalletAtom } from '@/atoms/walletAtoms'
 import { Store, AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
 
 function Login() {
@@ -20,6 +21,7 @@ function Login() {
   const [token] = useAtom(tokenAtom)
   const [, setToken] = useAtom(tokenAtom)
   const [, setUser] = useAtom(userAtom)
+  const loadWallet = useSetAtom(loadWalletAtom)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -42,6 +44,7 @@ function Login() {
 
       // Set user in atoms
       setUser(user)
+      await loadWallet()
 
       if (user.role === 'admin') {
         console.log('navigate..')

--- a/client/pages/LoginSIWE.tsx
+++ b/client/pages/LoginSIWE.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { tokenAtom, userAtom } from '@/atoms/loginAtoms'
+import { loadWalletAtom } from '@/atoms/walletAtoms'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -60,6 +61,7 @@ function LoginSIWE() {
   const navigate = useNavigate()
   const [, setToken] = useAtom(tokenAtom)
   const [, setUser] = useAtom(userAtom)
+  const loadWallet = useSetAtom(loadWalletAtom)
   const { open } = useAppKit()
   const { address, isConnected } = useAppKitAccount()
   const { walletProvider } = useAppKitProvider<unknown>('eip155')
@@ -113,6 +115,7 @@ function LoginSIWE() {
       const res = await axios.post('/api/login/siwe', { message, signature })
       setToken(res.data.token)
       setUser(res.data.user)
+      await loadWallet()
       navigate('/home', { replace: true })
     } catch (err) {
       console.log('!!!')

--- a/client/pages/buyer/Profile.tsx
+++ b/client/pages/buyer/Profile.tsx
@@ -1,5 +1,6 @@
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { userAtom } from '@/atoms/loginAtoms'
+import { balanceAtom, loadWalletAtom } from '@/atoms/walletAtoms'
 import { useState, useEffect } from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -18,6 +19,8 @@ function Profile() {
   const [username, setUsername] = useState(user?.username || '')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [balance] = useAtom(balanceAtom)
+  const loadWallet = useSetAtom(loadWalletAtom)
 
   // Update form when user data changes
   useEffect(() => {
@@ -26,6 +29,10 @@ function Profile() {
       setUsername(user.username || '')
     }
   }, [user])
+
+  useEffect(() => {
+    loadWallet()
+  }, [loadWallet])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -117,11 +124,20 @@ function Profile() {
             <User className="h-5 w-5 text-primary" />
           </div>
           <h1 className="text-3xl font-bold tracking-tight">Profile Settings</h1>
-        </div>
-        <p className="text-muted-foreground">
-          Manage your account information and preferences
-        </p>
       </div>
+      <p className="text-muted-foreground">
+        Manage your account information and preferences
+      </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Wallet Balance</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{balance}</p>
+        </CardContent>
+      </Card>
 
       {/* Profile Form */}
       <Card>

--- a/client/types/Wallet.ts
+++ b/client/types/Wallet.ts
@@ -1,0 +1,5 @@
+// Import Wallet type from schema.ts as the single source of truth
+export type { Wallet } from '@/server/schema'
+
+// Balance is stored as a string representing stablecoin amount
+export type Balance = string

--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -603,6 +603,25 @@ export function createErrorResponse(message: string): LoginError {
   return { MESSAGE: message };
 }
 
+/**
+ * Get wallet for authenticated user
+ */
+export async function getWallet(token: string): Promise<Wallet | null> {
+  const user = await validateToken(token);
+  if (!user) {
+    return null;
+  }
+
+  const db = await drizzleDb();
+  const rows = await db
+    .select()
+    .from(wallets)
+    .where(eq(wallets.userId, user.id))
+    .all();
+
+  return rows[0] || null;
+}
+
 // === SELLER CONTROLLERS ===
 
 /**

--- a/server/handlers.ts
+++ b/server/handlers.ts
@@ -42,6 +42,7 @@ import {
   updateUserProfile,
   registerUser,
   loginWithSiwe,
+  getWallet,
 } from './controllers';
 
 // === AUTHORIZATION HELPERS ===
@@ -167,6 +168,37 @@ export const handlers = [
       console.error('Login handler error:', error);
       return res(
         ctx.status(500), 
+        ctx.json(createErrorResponse('Internal server error'))
+      );
+    }
+  }),
+
+  // GET /api/wallet - Get current wallet balance
+  rest.get('/api/wallet', async (req, res, ctx) => {
+    try {
+      await addDelay();
+
+      const authResult = await requireAuth(req);
+      if (!authResult.success) {
+        return res(
+          ctx.status(authResult.error!.status),
+          ctx.json(createErrorResponse(authResult.error!.message))
+        );
+      }
+
+      const wallet = await getWallet(authResult.user.token);
+      if (!wallet) {
+        return res(
+          ctx.status(404),
+          ctx.json(createErrorResponse('Wallet not found'))
+        );
+      }
+
+      return res(ctx.status(200), ctx.json(wallet));
+    } catch (error) {
+      console.error('Get wallet error:', error);
+      return res(
+        ctx.status(500),
         ctx.json(createErrorResponse('Internal server error'))
       );
     }

--- a/spec.md
+++ b/spec.md
@@ -249,6 +249,12 @@ const removeFromCartAtom = atom(null, async (get,set,id:number)=>{...})
 const updateCartQuantityAtom = atom(null, async (get,set,{productId,quantity})=>{...})
 const clearCartAtom = atom(null, async (_get,set)=>{...})
 
+// Wallet state
+const walletAtom = atom<Wallet | null>(null)
+const balanceAtom = atom(get => get(walletAtom)?.balance ?? '0')
+const loadWalletAtom = atom(null, async (_get,set)=>{...})
+const clearWalletAtom = atom(null, async (_get,set)=>{...})
+
 // Seller products refresh signal
 const sellerProductsRefreshAtom = atom(0)
 const refreshSellerProductsAtom = atom(null, (get,set)=> set(sellerProductsRefreshAtom, get(sellerProductsRefreshAtom)+1))


### PR DESCRIPTION
## Summary
- implement wallet and balance atoms for Jotai
- export wallet types for the client
- load wallet info after login flows
- expose `GET /api/wallet` in mock handlers
- display wallet balance on buyer profile
- document wallet atoms in spec

## Testing
- `npm run lint`
- `npm run lint:openapi`


------
https://chatgpt.com/codex/tasks/task_b_687a44daf7c0832dbaa2b08d7df760bb