### PR TITLE
Implement wallet support with API and frontend

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -32,6 +32,8 @@ import ManageProducts from './pages/admin/ManageProducts'
 import AdminViewProduct from './pages/admin/ViewProduct'
 import Reports from './pages/admin/Reports'
 import SiteSettings from './pages/admin/SiteSettings'
+import WalletPage from './pages/Wallet'
+import ManageWallets from './pages/admin/ManageWallets'
 import Checkout from './pages/buyer/Checkout'
 import { Toaster } from './components/ui/sonner'
 
@@ -78,6 +80,7 @@ function App() {
               <Route path="/orders" element={<Orders />} />
               <Route path="/orders/:id" element={<OrderDetail />} />
               <Route path="/profile" element={<Profile />} />
+              <Route path="/wallet" element={<WalletPage />} />
               <Route path="/buyer/product/:id" element={<ProductDetail />} />
 
               {/* Seller Routes */}
@@ -104,6 +107,7 @@ function App() {
               <Route path="/admin/sellers" element={<ManageSellers />} />
               <Route path="/admin/sellers/:id" element={<ViewSeller />} />
               <Route path="/admin/products" element={<ManageProducts />} />
+              <Route path="/admin/wallets" element={<ManageWallets />} />
               <Route
                 path="/admin/products/:id"
                 element={<AdminViewProduct />}

--- a/client/components/Navbar.tsx
+++ b/client/components/Navbar.tsx
@@ -30,6 +30,7 @@ import {
   BarChart3,
   Users,
   FileText,
+  Wallet,
   Menu,
   X,
 } from 'lucide-react'
@@ -108,6 +109,12 @@ function Navbar() {
       icon: User,
       description: 'Manage your account settings',
     },
+    {
+      label: 'Wallet',
+      path: '/wallet',
+      icon: Wallet,
+      description: 'View your wallet balance',
+    },
   ]
 
   const getSellerNavItems = () => [
@@ -134,6 +141,12 @@ function Navbar() {
       path: '/seller/payouts',
       icon: Store,
       description: 'Track your earnings and payouts',
+    },
+    {
+      label: 'Wallet',
+      path: '/wallet',
+      icon: Wallet,
+      description: 'View your wallet balance',
     },
     {
       label: 'Store Profile',
@@ -173,6 +186,12 @@ function Navbar() {
       path: '/admin/reports',
       icon: FileText,
       description: 'Handle user reports and issues',
+    },
+    {
+      label: 'Wallets',
+      path: '/admin/wallets',
+      icon: Wallet,
+      description: 'View all user wallets',
     },
     {
       label: 'Settings',

--- a/client/pages/Wallet.tsx
+++ b/client/pages/Wallet.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import axios from '@/lib/axios'
+import type { Wallet } from '@/types/Wallet'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+function WalletPage() {
+  const [wallet, setWallet] = useState<Wallet | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchWallet = async () => {
+      setLoading(true)
+      try {
+        const res = await axios.get<Wallet>('/api/wallet')
+        setWallet(res.data)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchWallet()
+  }, [])
+
+  if (loading || !wallet) {
+    return <Skeleton className="h-24 w-full" />
+  }
+
+  return (
+    <Card className="max-w-sm">
+      <CardHeader>
+        <CardTitle>Your Wallet</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">Balance</p>
+        <p className="text-2xl font-bold">{wallet.balance}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default WalletPage
+

--- a/client/pages/admin/ManageWallets.tsx
+++ b/client/pages/admin/ManageWallets.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import axios from '@/lib/axios'
+import { DataTable } from '@/components/DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import type { Wallet } from '@/types/Wallet'
+
+function ManageWallets() {
+  const [data, setData] = useState<Wallet[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = async () => {
+    setLoading(true)
+    const res = await axios.get<Wallet[]>('/api/admin/wallets')
+    setData(res.data)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const columns: ColumnDef<Wallet>[] = [
+    { accessorKey: 'id', header: 'ID', meta: { widthClass: 'w-16' } },
+    { accessorKey: 'userId', header: 'User ID', meta: { widthClass: 'w-20' } },
+    { accessorKey: 'balance', header: 'Balance', meta: { widthClass: 'w-32' } },
+    { accessorKey: 'updatedAt', header: 'Updated', meta: { widthClass: 'w-40' } },
+  ]
+
+  return <DataTable columns={columns} data={data} isLoading={loading} />
+}
+
+export default ManageWallets
+

--- a/client/types/Wallet.ts
+++ b/client/types/Wallet.ts
@@ -1,0 +1,3 @@
+// Import Wallet type from schema.ts as the single source of truth
+export type { Wallet } from '@/server/schema'
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -308,7 +308,7 @@ paths:
     get:
       operationId: getWallet
       summary: Get current wallet balance
-      description: Retrieve the wallet information for the authenticated user.
+      description: Retrieve the stablecoin wallet information for the authenticated user.
       tags:
       - Wallet
       security:
@@ -1117,7 +1117,7 @@ paths:
     get:
       operationId: getAllWallets
       summary: Get all user wallets
-      description: Retrieve wallets for all users (admin only)
+      description: Retrieve stablecoin wallets for all users (admin only)
       tags:
       - Admin
       security:
@@ -2927,7 +2927,7 @@ components:
           example: 2
         balance:
           type: string
-          description: Current stablecoin balance
+          description: Current stablecoin balance stored as a string for precision
           example: "0"
         createdAt:
           type: string

--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -1092,4 +1092,27 @@ export async function createBuyerOrder(token: string, orderData: {
   return createdOrders[0] || null;
 }
 
+// === WALLET CONTROLLERS ===
+
+export async function getWallet(token: string): Promise<Wallet | null> {
+  const user = await validateToken(token)
+  if (!user) {
+    return null
+  }
+
+  const db = await drizzleDb()
+  const walletRows = await db
+    .select()
+    .from(wallets)
+    .where(eq(wallets.userId, user.id))
+    .all()
+
+  return walletRows[0] || null
+}
+
+export async function getAllWallets(): Promise<Wallet[]> {
+  const db = await drizzleDb()
+  return await db.select().from(wallets).all()
+}
+
 // === EXISTING CONTROLLERS ===

--- a/server/handlers.ts
+++ b/server/handlers.ts
@@ -42,6 +42,8 @@ import {
   updateUserProfile,
   registerUser,
   loginWithSiwe,
+  getWallet,
+  getAllWallets,
 } from './controllers';
 
 // === AUTHORIZATION HELPERS ===
@@ -1077,6 +1079,51 @@ export const handlers = [
       if (error instanceof Error && error.message === 'Access denied') {
         return res(ctx.status(403), ctx.json(createErrorResponse('Access denied')));
       }
+      return res(ctx.status(500), ctx.json(createErrorResponse('Internal server error')));
+    }
+  }),
+
+  // GET /api/wallet - Get current user's wallet
+  rest.get('/api/wallet', async (req, res, ctx) => {
+    try {
+      await addDelay();
+      const authResult = await requireAuth(req);
+      if (!authResult.success) {
+        return res(
+          ctx.status(authResult.error!.status),
+          ctx.json(createErrorResponse(authResult.error!.message))
+        );
+      }
+
+      const wallet = await getWallet(authResult.user.token);
+
+      if (!wallet) {
+        return res(ctx.status(404), ctx.json(createErrorResponse('Wallet not found')));
+      }
+
+      return res(ctx.status(200), ctx.json(wallet));
+    } catch (error) {
+      console.error('Get wallet error:', error);
+      return res(ctx.status(500), ctx.json(createErrorResponse('Internal server error')));
+    }
+  }),
+
+  // GET /api/admin/wallets - Get all wallets
+  rest.get('/api/admin/wallets', async (req, res, ctx) => {
+    try {
+      await addDelay();
+      const authResult = await requireAdmin(req);
+      if (!authResult.success) {
+        return res(
+          ctx.status(authResult.error!.status),
+          ctx.json(createErrorResponse(authResult.error!.message))
+        );
+      }
+
+      const wallets = await getAllWallets();
+      return res(ctx.status(200), ctx.json(wallets));
+    } catch (error) {
+      console.error('Get all wallets error:', error);
       return res(ctx.status(500), ctx.json(createErrorResponse('Internal server error')));
     }
   }),

--- a/spec.md
+++ b/spec.md
@@ -87,7 +87,7 @@ export interface Setting {
 export interface Wallet {
   id: number
   userId: number
-  balance: string
+  balance: string // stablecoin balance stored as a string for precision
   createdAt: string | null
   updatedAt: string | null
 }


### PR DESCRIPTION
## Summary
- add wallet fetch controllers and handlers
- document wallet model and endpoints in spec and OpenAPI docs
- implement buyer/seller/admin wallet pages and navbar links
- expose wallet route in app router

## Testing
- `npm run lint`
- `npm run lint:openapi`


------
https://chatgpt.com/codex/tasks/task_b_687a4516e5a4832d9be56b398384f198