### PR TITLE
Audit backend and clean up

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,22 @@
+# Backend Architecture Overview
+
+This document summarizes the current server side data model and authentication logic.
+
+## Database Schema
+
+The SQLite database is created in memory using `drizzle-orm`. The main tables are:
+
+- **users** – stores user credentials and roles (`admin`, `buyer`, `seller`).
+- **sellers** – profile information for seller accounts.
+- **products** – items offered by sellers.
+- **orders** – purchase records for buyers.
+- **sellerPayouts** – payouts issued to sellers.
+- **reports** – user reports handled by admins.
+- **settings** – key/value application settings.
+
+There are no tables related to wallets, balances or ledgers beyond the `orders` and `sellerPayouts` records.
+
+## Authentication
+
+Tokens are simple Base64 encodings of the user ID generated in `generateToken`. Validation occurs via `validateToken` which looks up the corresponding user. No additional balance or wallet logic is present.
+

--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -1037,4 +1037,3 @@ export async function createBuyerOrder(token: string, orderData: {
   return createdOrders[0] || null;
 }
 
-// === EXISTING CONTROLLERS ===

--- a/server/db.ts
+++ b/server/db.ts
@@ -5,7 +5,11 @@ import { createTableStatements } from './schema'
 import { seedDb } from './seed'
 let db: ReturnType<typeof drizzle> | null = null
 
-export async function initDrizzle() {
+/**
+ * Initialize the in-memory SQLite database and return a drizzle instance.
+ * The database is seeded on first initialization.
+ */
+export async function initDrizzle(): Promise<ReturnType<typeof drizzle>> {
   if (db) return db // Already initialized
 
   const SQL = await initSqlJs({
@@ -18,12 +22,10 @@ export async function initDrizzle() {
   const sqlite = new SQL.Database()
   db = drizzle(sqlite, { schema })
 
-for (const statement of createTableStatements) {
-    await db.run(statement);
+  for (const statement of createTableStatements) {
+    await db.run(statement)
   }
-  // const tables = await db.all(
-  //   "SELECT name FROM sqlite_master WHERE type='table';"
-  // )
+
   console.log('[sql.js] DB ready!')
 
   await seedDb(db)
@@ -33,6 +35,9 @@ for (const statement of createTableStatements) {
 // Always returns the same Promise if already running
 let dbPromise: Promise<ReturnType<typeof drizzle>> | null = null
 
+/**
+ * Get the drizzle database instance, initializing it if necessary.
+ */
 export function drizzleDb(): Promise<ReturnType<typeof drizzle>> {
   if (!dbPromise) {
     dbPromise = initDrizzle()


### PR DESCRIPTION
## Summary
- document server architecture in `docs/architecture.md`
- add documentation comments and cleanup `server/db.ts`
- remove leftover comment from `server/controllers.ts`

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run lint:openapi`


------
https://chatgpt.com/codex/tasks/task_b_687a76b6701c832dbdd822263c4ec5e6