### PR TITLE
Implement SIWE-only authentication backend

### DIFF
--- a/server/handlers.ts
+++ b/server/handlers.ts
@@ -1,6 +1,5 @@
 import { rest } from 'msw';
 import {
-  loginByUsernamePassword,
   validateToken,
   getSettings,
   checkAdminAccess,
@@ -144,40 +143,13 @@ async function addDelay(): Promise<void> {
 export const handlers = [
   // === AUTHENTICATION ===
   
-  // POST /api/login - Authenticate user
-  rest.post('/api/login', async (req, res, ctx) => {
-    try {
-      await addDelay();
-      
-      const body = await req.json();
-      
-      // Use controller to handle login
-      const result = await loginByUsernamePassword(body);
-      
-      // If error, return appropriate status
-      if ('MESSAGE' in result) {
-        if (result.MESSAGE.includes('required') || result.MESSAGE.includes('Invalid request')) {
-          return res(ctx.status(400), ctx.json(result));
-        }
-        if (result.MESSAGE.includes('Invalid username or password')) {
-          return res(ctx.status(401), ctx.json(result));
-        }
-        if (result.MESSAGE.includes('banned')) {
-          return res(ctx.status(403), ctx.json(result));
-        }
-        return res(ctx.status(500), ctx.json(result));
-      }
-      
-      // Success response
-      return res(ctx.status(200), ctx.json(result));
-      
-    } catch (error) {
-      console.error('Login handler error:', error);
-      return res(
-        ctx.status(500), 
-        ctx.json(createErrorResponse('Internal server error'))
-      );
-    }
+  // POST /api/login - Authenticate user (disabled)
+  rest.post('/api/login', async (_req, res, ctx) => {
+    await addDelay();
+    return res(
+      ctx.status(400),
+      ctx.json(createErrorResponse('Password login disabled')),
+    );
   }),
 
   // POST /api/login/siwe - Authenticate via Sign-In with Ethereum

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, test, expect } from '@jest/globals';
+import { drizzleDb } from '@/server/db';
+import { promises as fs } from 'fs';
+import path from 'node:path';
+import { loginWithSiwe, validateToken, resetSiweRateLimit } from '@/server/controllers';
+import { Wallet, getAddress } from 'ethers';
+import { SiweMessage } from 'siwe';
+
+beforeAll(async () => {
+  try {
+    await fs.access('/webappx/sql-wasm.wasm');
+  } catch {
+    await fs.mkdir('/webappx', { recursive: true });
+    await fs.copyFile(
+      path.join(process.cwd(), 'node_modules/sql.js/dist/sql-wasm.wasm'),
+      '/webappx/sql-wasm.wasm'
+    );
+  }
+  await drizzleDb();
+});
+
+function buildMessage(address: string, nonce: string = Math.random().toString(36).substring(2, 10)): string {
+  const msg = new SiweMessage({
+    domain: 'localhost',
+    address: getAddress(address),
+    statement: 'Sign in with Ethereum to WebAppX',
+    uri: 'http://localhost',
+    version: '1',
+    chainId: 1,
+    nonce,
+    issuedAt: new Date().toISOString(),
+  });
+  return msg.prepareMessage();
+}
+
+test('loginWithSiwe creates user and returns token', async () => {
+  const wallet = Wallet.createRandom();
+  const message = buildMessage(wallet.address);
+  const signature = await wallet.signMessage(message);
+  const res = await loginWithSiwe({ message, signature });
+  expect('token' in res).toBe(true);
+  if ('token' in res) {
+    const user = await validateToken(res.token);
+    expect(user?.ethereumAddress).toBe(wallet.address.toLowerCase());
+  }
+});
+
+test('invalid signature fails', async () => {
+  const wallet = Wallet.createRandom();
+  const message = buildMessage(wallet.address);
+  const signature = await wallet.signMessage(message);
+  const badMessage = message.replace('WebAppX', 'Other');
+  const res = await loginWithSiwe({ message: badMessage, signature });
+  expect('MESSAGE' in res).toBe(true);
+});
+
+test('test address bypasses signature check', async () => {
+  const message = buildMessage('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  const res = await loginWithSiwe({ message, signature: '0x0' });
+  expect('token' in res).toBe(true);
+});
+
+test('rate limiting', async () => {
+  resetSiweRateLimit();
+  const wallet = Wallet.createRandom();
+  const message = buildMessage(wallet.address);
+  const signature = await wallet.signMessage(message);
+  let last: Awaited<ReturnType<typeof loginWithSiwe>> | undefined;
+  for (let i = 0; i < 6; i++) {
+     
+    last = await loginWithSiwe({ message, signature });
+  }
+  if (last && typeof last === 'object' && 'MESSAGE' in last) {
+    expect(last.MESSAGE).toBe('Too many requests');
+  } else {
+    throw new Error('Expected rate limit error');
+  }
+});

--- a/tests/payment.test.ts
+++ b/tests/payment.test.ts
@@ -15,6 +15,7 @@ beforeAll(async () => {
   try {
     await fs.access('/webappx/sql-wasm.wasm');
   } catch {
+    await fs.mkdir('/webappx', { recursive: true });
     await fs.copyFile(
       path.join(process.cwd(), 'node_modules/sql.js/dist/sql-wasm.wasm'),
       '/webappx/sql-wasm.wasm',

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -19,6 +19,7 @@ beforeAll(async () => {
   try {
     await fs.access('/webappx/sql-wasm.wasm');
   } catch {
+    await fs.mkdir('/webappx', { recursive: true });
     await fs.copyFile(
       path.join(process.cwd(), 'node_modules/sql.js/dist/sql-wasm.wasm'),
       '/webappx/sql-wasm.wasm',


### PR DESCRIPTION
## Summary
- remove password-based login logic
- improve `loginWithSiwe` with rate limiting and test user bypass
- disable legacy login endpoint
- ensure tests create wasm directory
- add unit tests for SIWE auth flow

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687bbec9e350832d95aa309a49878646