### PR TITLE
Remove deprecated login endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,101 +12,6 @@ servers:
 - url: https://api.webappx.com
   description: Production server
 paths:
-  /api/login:
-    post:
-      operationId: loginUser
-      summary: Authenticate user
-      description: Authenticate a user with username and password, returning a token
-        and user information. This endpoint is publicly accessible and does not require
-        authorization.
-      tags:
-      - Authentication
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LoginRequest'
-            examples:
-              admin_user:
-                summary: Admin user login
-                value:
-                  username: alice
-                  password: alice
-              buyer_user:
-                summary: Buyer user login
-                value:
-                  username: bob
-                  password: bob
-              seller_user:
-                summary: Seller user login
-                value:
-                  username: carol
-                  password: carol
-      responses:
-        '200':
-          description: Login successful
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoginResponse'
-        '400':
-          description: Bad request - invalid input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                missing_credentials:
-                  summary: Missing credentials
-                  value:
-                    MESSAGE: Username and password are required
-                invalid_format:
-                  summary: Invalid format
-                  value:
-                    MESSAGE: Invalid username or password format
-        '401':
-          description: Unauthorized - invalid or missing authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                invalid_credentials:
-                  summary: Invalid credentials
-                  value:
-                    MESSAGE: Invalid username or password
-                invalid_token:
-                  summary: Invalid token
-                  value:
-                    MESSAGE: Invalid authentication token
-        '403':
-          description: Forbidden - insufficient permissions
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                access_denied:
-                  summary: Access denied
-                  value:
-                    MESSAGE: Access denied
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                server_error:
-                  summary: Server error
-                  value:
-                    MESSAGE: Internal server error
-                database_error:
-                  summary: Database error
-                  value:
-                    MESSAGE: Database connection failed
   /api/login/siwe:
     post:
       operationId: loginWithSiwe
@@ -3009,24 +2914,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
-    LoginRequest:
-      type: object
-      required:
-      - username
-      - password
-      properties:
-        username:
-          type: string
-          description: User's username
-          example: alice
-          minLength: 1
-          maxLength: 50
-        password:
-          type: string
-          description: User's password
-          example: alice
-          minLength: 1
-      maxLength: 100
     RegisterRequest:
       type: object
       required:

--- a/server/handlers.ts
+++ b/server/handlers.ts
@@ -143,14 +143,6 @@ async function addDelay(): Promise<void> {
 export const handlers = [
   // === AUTHENTICATION ===
   
-  // POST /api/login - Authenticate user (disabled)
-  rest.post('/api/login', async (_req, res, ctx) => {
-    await addDelay();
-    return res(
-      ctx.status(400),
-      ctx.json(createErrorResponse('Password login disabled')),
-    );
-  }),
 
   // POST /api/login/siwe - Authenticate via Sign-In with Ethereum
   rest.post('/api/login/siwe', async (req, res, ctx) => {

--- a/tests/loginEndpoint.test.ts
+++ b/tests/loginEndpoint.test.ts
@@ -1,0 +1,112 @@
+import { beforeAll, afterAll, afterEach, test, expect } from '@jest/globals';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import axios from 'axios';
+import { drizzleDb } from '@/server/db';
+import { promises as fs } from 'fs';
+import path from 'node:path';
+import { Wallet, getAddress } from 'ethers';
+import { SiweMessage } from 'siwe';
+import { resetSiweRateLimit, loginWithSiwe } from '@/server/controllers';
+
+const server = setupServer(
+  rest.post('http://localhost/api/login/siwe', async (req, res, ctx) => {
+    const body = await req.json();
+    const result = await loginWithSiwe(body);
+    if ('MESSAGE' in result) {
+      return res(ctx.status(400), ctx.json(result));
+    }
+    return res(ctx.status(200), ctx.json(result));
+  }),
+);
+
+function buildMessage(
+  address: string,
+  nonce: string = Math.random().toString(36).substring(2, 10),
+): string {
+  const msg = new SiweMessage({
+    domain: 'localhost',
+    address: getAddress(address),
+    statement: 'Sign in with Ethereum to WebAppX',
+    uri: 'http://localhost',
+    version: '1',
+    chainId: 1,
+    nonce,
+    issuedAt: new Date().toISOString(),
+  });
+  return msg.prepareMessage();
+}
+
+async function ensureSqlWasm() {
+  try {
+    await fs.access('/webappx/sql-wasm.wasm');
+  } catch {
+    await fs.mkdir('/webappx', { recursive: true });
+    await fs.copyFile(
+      path.join(process.cwd(), 'node_modules/sql.js/dist/sql-wasm.wasm'),
+      '/webappx/sql-wasm.wasm',
+    );
+  }
+}
+
+beforeAll(async () => {
+  await ensureSqlWasm();
+  await drizzleDb();
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  resetSiweRateLimit();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+test('POST /api/login/siwe returns token and user', async () => {
+  const wallet = Wallet.createRandom();
+  const message = buildMessage(wallet.address);
+  const signature = await wallet.signMessage(message);
+  const res = await axios.post('http://localhost/api/login/siwe', {
+    message,
+    signature,
+  });
+  expect(res.status).toBe(200);
+  expect(res.data).toHaveProperty('token');
+  expect(res.data.user.ethereumAddress).toBe(wallet.address.toLowerCase());
+});
+
+test('test users authenticate regardless of signature', async () => {
+  const message = buildMessage(
+    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  );
+  const res = await axios.post('http://localhost/api/login/siwe', {
+    message,
+    signature: '0x0',
+  });
+  expect(res.status).toBe(200);
+  expect(res.data.user.username).toBe('alice');
+});
+
+test('invalid signature returns error', async () => {
+  const wallet = Wallet.createRandom();
+  const message = buildMessage(wallet.address);
+  const badMessage = message.replace('WebAppX', 'Other');
+  const signature = await wallet.signMessage(message);
+  try {
+    await axios.post('http://localhost/api/login/siwe', {
+      message: badMessage,
+      signature,
+    });
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response) {
+      expect(err.response.status).toBe(400);
+      expect(err.response.data).toHaveProperty('MESSAGE');
+      return;
+    }
+    throw err;
+  }
+  throw new Error('Request should have failed');
+});
+


### PR DESCRIPTION
## Summary
- delete `/api/login` handler and spec
- keep only SIWE login endpoint in API docs
- add tests for the SIWE login handler

## Testing
- `npm run format`
- `npm run lint`
- `npm run lint:openapi`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687bc5b3b1dc832d811fff8684caf722