### PR TITLE
Implement admin wallet management

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -32,6 +32,7 @@ import ManageProducts from './pages/admin/ManageProducts';
 import AdminViewProduct from './pages/admin/ViewProduct';
 import Reports from './pages/admin/Reports';
 import SiteSettings from './pages/admin/SiteSettings';
+import WalletUserManager from './pages/admin/WalletUserManager';
 import Checkout from './pages/buyer/Checkout';
 import AccountRecovery from './pages/AccountRecovery';
 import { Toaster } from './components/ui/sonner';
@@ -103,6 +104,7 @@ function App() {
               <Route path="/admin" element={<AdminDashboard />} />
               <Route path="/admin/users" element={<ManageUsers />} />
               <Route path="/admin/users/:id" element={<ViewUser />} />
+              <Route path="/admin/wallets" element={<WalletUserManager />} />
               <Route path="/admin/sellers" element={<ManageSellers />} />
               <Route path="/admin/sellers/:id" element={<ViewSeller />} />
               <Route path="/admin/products" element={<ManageProducts />} />

--- a/client/components/Navbar.tsx
+++ b/client/components/Navbar.tsx
@@ -30,6 +30,7 @@ import {
   BarChart3,
   Users,
   FileText,
+  CreditCard,
   Menu,
   X,
 } from 'lucide-react';
@@ -169,6 +170,12 @@ function Navbar() {
       path: '/admin/products',
       icon: Package,
       description: 'Review and moderate products',
+    },
+    {
+      label: 'Wallets',
+      path: '/admin/wallets',
+      icon: CreditCard,
+      description: 'Manage user wallets',
     },
     {
       label: 'Reports',

--- a/client/pages/admin/AdminDashboard.tsx
+++ b/client/pages/admin/AdminDashboard.tsx
@@ -8,6 +8,7 @@ interface Stats {
   totalSellers: number;
   totalSales: number;
   openReports: number;
+  totalWallets: number;
 }
 
 function AdminDashboard() {
@@ -54,6 +55,10 @@ function AdminDashboard() {
       <div className="p-4 border rounded">
         <p className="text-sm text-muted-foreground">Open Reports</p>
         <p className="text-2xl font-bold">{stats.openReports}</p>
+      </div>
+      <div className="p-4 border rounded">
+        <p className="text-sm text-muted-foreground">Total Wallets</p>
+        <p className="text-2xl font-bold">{stats.totalWallets}</p>
       </div>
     </div>
   );

--- a/client/pages/admin/ManageUsers.tsx
+++ b/client/pages/admin/ManageUsers.tsx
@@ -72,6 +72,11 @@ function ManageUsers() {
       meta: { widthClass: 'w-40', cellClass: 'truncate' },
     },
     {
+      accessorKey: 'ethereumAddress',
+      header: 'Address',
+      meta: { widthClass: 'hidden md:table-cell w-64', cellClass: 'truncate' },
+    },
+    {
       accessorKey: 'role',
       header: 'Role',
       cell: ({ row }) => (

--- a/client/pages/admin/WalletUserManager.tsx
+++ b/client/pages/admin/WalletUserManager.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import axios from '@/lib/axios';
+import { DataTable } from '@/components/DataTable';
+import type { ColumnDef } from '@tanstack/react-table';
+import type { Wallet, PublicUser } from '@/server/schema';
+
+interface WalletRow extends Wallet {
+  username: string;
+  ethereumAddress: string;
+}
+
+function WalletUserManager() {
+  const [data, setData] = useState<WalletRow[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchData = async () => {
+    setLoading(true);
+    const [walletRes, userRes] = await Promise.all([
+      axios.get<Wallet[]>('/api/admin/wallets'),
+      axios.get<PublicUser[]>('/api/admin/users'),
+    ]);
+    const userMap = new Map(userRes.data.map((u) => [u.id, u]));
+    setData(
+      walletRes.data.map((w) => ({
+        ...w,
+        username: userMap.get(w.userId)?.username || '',
+        ethereumAddress: userMap.get(w.userId)?.ethereumAddress || '',
+      }))
+    );
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const columns: ColumnDef<WalletRow>[] = [
+    { accessorKey: 'userId', header: 'User ID', meta: { widthClass: 'w-16' } },
+    {
+      accessorKey: 'username',
+      header: 'Username',
+      meta: { widthClass: 'w-32', cellClass: 'truncate' },
+    },
+    {
+      accessorKey: 'ethereumAddress',
+      header: 'Address',
+      meta: { widthClass: 'w-64', cellClass: 'truncate' },
+    },
+    { accessorKey: 'balance', header: 'Balance', meta: { widthClass: 'w-24' } },
+  ];
+
+  return <DataTable columns={columns} data={data} isLoading={loading} />;
+}
+
+export default WalletUserManager;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3205,6 +3205,7 @@ components:
       - totalSellers
       - totalSales
       - openReports
+      - totalWallets
       properties:
         totalUsers:
           type: integer
@@ -3223,6 +3224,10 @@ components:
           type: integer
           description: Number of open reports
           example: 5
+        totalWallets:
+          type: integer
+          description: Number of registered wallets
+          example: 150
     CartItem:
       type: object
       required:

--- a/server/controllers.ts
+++ b/server/controllers.ts
@@ -266,11 +266,17 @@ export async function getDashboardStats(): Promise<DashboardStats> {
     .where(eq(reports.status, 'open'))
     .all();
 
+  const [{ count: totalWallets }] = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(wallets)
+    .all();
+
   return {
     totalUsers,
     totalSellers,
     totalSales,
     openReports,
+    totalWallets,
   };
 }
 

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -165,6 +165,7 @@ export interface DashboardStats {
   totalSellers: number
   totalSales: number
   openReports: number
+  totalWallets: number
 }
 
 // Export all types from drizzle schemas

--- a/tests/adminDashboard.test.tsx
+++ b/tests/adminDashboard.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+(globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder }).TextEncoder = TextEncoder;
+(globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder }).TextDecoder = TextDecoder;
+import { HashRouter } from 'react-router-dom';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import AdminDashboard from '@/pages/admin/AdminDashboard';
+
+const server = setupServer(
+  rest.get('/api/admin/dashboard', (_req, res, ctx) =>
+    res(
+      ctx.json({ totalUsers: 1, totalSellers: 1, totalSales: 0, openReports: 0, totalWallets: 1 })
+    )
+  )
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('shows total wallets on dashboard', async () => {
+  render(
+    <HashRouter>
+      <AdminDashboard />
+    </HashRouter>
+  );
+  const label = await screen.findByText('Total Wallets');
+  expect(label).toBeInTheDocument();
+  expect(label.nextSibling?.textContent).toBe('1');
+});

--- a/tests/manageUsersWalletColumn.test.tsx
+++ b/tests/manageUsersWalletColumn.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+(globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder }).TextEncoder = TextEncoder;
+(globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder }).TextDecoder = TextDecoder;
+import { HashRouter } from 'react-router-dom';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import ManageUsers from '@/pages/admin/ManageUsers';
+
+const server = setupServer(
+  rest.get('/api/admin/users', (_req, res, ctx) =>
+    res(
+      ctx.json([
+        {
+          id: 1,
+          name: 'Alice',
+          username: 'alice',
+          ethereumAddress: '0xabc',
+          authMethod: 'siwe',
+          role: 'buyer',
+          status: 'active',
+          createdAt: '',
+          updatedAt: '',
+        },
+      ])
+    )
+  )
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('shows ethereum address column', async () => {
+  render(
+    <HashRouter>
+      <ManageUsers />
+    </HashRouter>
+  );
+  expect(await screen.findByText('Address')).toBeInTheDocument();
+  expect((await screen.findAllByText('0xabc')).length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- track wallet count in `DashboardStats`
- expose wallet count from backend
- display wallet totals on Admin Dashboard
- show wallet addresses on user management page
- add WalletUserManager admin page and routing
- expand OpenAPI spec for wallet counts
- add admin dashboard and user wallet tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run lint:openapi`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c34bc98a4832d98ecc27c18862b6e