### PR TITLE
Fix catalog header layout on small screens

### DIFF
--- a/client/pages/buyer/Catalog.tsx
+++ b/client/pages/buyer/Catalog.tsx
@@ -126,7 +126,7 @@ function Catalog() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div className="space-y-1">
           <h1 className="text-3xl font-bold tracking-tight">Product Catalog</h1>
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
             <div className="flex items-center gap-2">
               <Package className="h-4 w-4" />
               <span>{products.length} products</span>


### PR DESCRIPTION
## Summary
- allow the catalog header counters to wrap on small screens

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c7d95a63c832d94ff2f1f5ab9cfad