### PR TITLE
Redirect to login if not authenticated on checkout

### DIFF
--- a/client/pages/buyer/Checkout.tsx
+++ b/client/pages/buyer/Checkout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { cartAtom, clearCartAtom } from '@/atoms/cartAtoms';
+import { isAuthenticatedAtom } from '@/atoms/loginAtoms';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import axios from '@/lib/axios';
@@ -17,6 +18,7 @@ import {
 
 function Checkout() {
   const cart = useAtomValue(cartAtom);
+  const isAuthenticated = useAtomValue(isAuthenticatedAtom);
   const clearCart = useSetAtom(clearCartAtom);
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -29,6 +31,10 @@ function Checkout() {
   );
 
   const handleCheckout = async () => {
+    if (!isAuthenticated) {
+      navigate('/login');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -87,7 +93,13 @@ function Checkout() {
             </div>
             {error && <div className="text-red-600">{error}</div>}
             <Button
-              onClick={() => setConfirmCheckout(true)}
+              onClick={() => {
+                if (!isAuthenticated) {
+                  navigate('/login');
+                } else {
+                  setConfirmCheckout(true);
+                }
+              }}
               disabled={loading}
               className="w-full"
             >

--- a/tests/checkoutPage.test.tsx
+++ b/tests/checkoutPage.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+(globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder }).TextEncoder = TextEncoder;
+(globalThis as unknown as { TextEncoder: typeof TextEncoder; TextDecoder: typeof TextDecoder }).TextDecoder = TextDecoder;
+import { HashRouter } from 'react-router-dom';
+import { getDefaultStore } from 'jotai';
+import Checkout from '@/pages/buyer/Checkout';
+import { cartAtom } from '@/atoms/cartAtoms';
+import { tokenAtom, userAtom } from '@/atoms/loginAtoms';
+
+const navigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+test('redirects to login when placing order while not authenticated', () => {
+  const store = getDefaultStore();
+  store.set(cartAtom, [
+    {
+      id: 1,
+      userId: 0,
+      productId: 1,
+      quantity: 1,
+      product: {
+        id: 1,
+        name: 'Prod',
+        price: 10,
+        description: '',
+        imageUrl: '',
+        sellerId: 1,
+        status: '',
+        createdAt: '',
+        updatedAt: '',
+      },
+    },
+  ]);
+  store.set(tokenAtom, null);
+  store.set(userAtom, null);
+
+  render(
+    <HashRouter>
+      <Checkout />
+    </HashRouter>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /place order/i }));
+  expect(navigate).toHaveBeenCalledWith('/login');
+});


### PR DESCRIPTION
## Summary
- prevent unauthenticated users from placing orders by redirecting to login
- test checkout page navigation when the user isn't logged in

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687c811172c4832d8f640f45af8e7ed3